### PR TITLE
Turns off unused radios.

### DIFF
--- a/Aircraft/JA37/JA37-Viggen-set.xml
+++ b/Aircraft/JA37/JA37-Viggen-set.xml
@@ -1445,9 +1445,17 @@
             <power-good type="bool">false</power-good>
         </comm>
         <comm n="1">
-            <power-btn type="bool">true</power-btn>
+            <power-btn type="bool">false</power-btn>
             <power-good type="bool">false</power-good>
+			<volume type="double">0</volume>
         </comm>
+		<nav n="1">
+			<volume type="double">0</volume>
+		</nav>
+		<adf n="1">
+			<volume type="double">0</volume>
+			<volume-norm type="double">0</volume>
+		</adf>
         <instrumentation-light>
             <serviceable type="bool">true</serviceable>
         </instrumentation-light>


### PR DESCRIPTION
Sets the volume of adf[1], comm[1], and nav[1] to zero, as there's no way to interface with them outside of the property browser, and having a repeating ATIS message come blaring on for no apparent reason while trying to dogfight gets obnoxious (from personal experience last weekend).