### PR TITLE
Fix altimiter pick animation bug.

### DIFF
--- a/Aircraft/JA37/Models/Instruments/Altimeter2/altimeter2.xml
+++ b/Aircraft/JA37/Models/Instruments/Altimeter2/altimeter2.xml
@@ -291,7 +291,7 @@
             <binding>
                 <command>property-adjust</command>
                 <property>instrumentation/altimeter/setting-inhg</property>
-                <step>0.005</step>
+                <step>-0.005</step>
                 <min>26.0</min>
                 <max>33.0</max>
                 <wrap>false</wrap>

--- a/Aircraft/JA37/Models/Instruments/Altimeter2/altimeter2.xml
+++ b/Aircraft/JA37/Models/Instruments/Altimeter2/altimeter2.xml
@@ -274,7 +274,7 @@
             <binding>
                 <command>property-adjust</command>
                 <property>instrumentation/altimeter/setting-inhg</property>
-                <step>0.005</step>
+                <step>-0.005</step>
                 <min>26.0</min>
                 <max>33.0</max>
                 <wrap>false</wrap>
@@ -291,7 +291,7 @@
             <binding>
                 <command>property-adjust</command>
                 <property>instrumentation/altimeter/setting-inhg</property>
-                <step>-0.005</step>
+                <step>0.005</step>
                 <min>26.0</min>
                 <max>33.0</max>
                 <wrap>false</wrap>


### PR DESCRIPTION
This was a small bug that drove me nuts.
The altimeter on the right side would increase the inHg reading, whether you scrolled up or scrolled down on the computer mouse. Now, middle mouse down decreases the inHg.