### PR TITLE
Fix cockpit augStage lighting animations.

### DIFF
--- a/Aircraft/JA37/Models/Cockpit/augStage.xml
+++ b/Aircraft/JA37/Models/Cockpit/augStage.xml
@@ -52,6 +52,10 @@
                 <property>systems/electrical/outputs/dc-voltage</property>
                 <value>23</value>
             </greater-than>
+			<equals>
+				<property>controls/engines/engine[0]/cutoff-augmentation</property>
+				<value>0</value>
+			</equals>
         </condition>
         <emission>
             <red-prop>instrumentation/instrumentation-light/r</red-prop>
@@ -79,6 +83,10 @@
                 <property>systems/electrical/outputs/dc-voltage</property>
                 <value>23</value>
             </greater-than>
+			<equals>
+				<property>controls/engines/engine[0]/cutoff-augmentation</property>
+				<value>0</value>
+			</equals>
         </condition>
         <emission>
             <red-prop>instrumentation/instrumentation-light/r</red-prop>
@@ -100,6 +108,10 @@
                 <property>systems/electrical/outputs/dc-voltage</property>
                 <value>23</value>
             </greater-than>
+			<equals>
+				<property>controls/engines/engine[0]/cutoff-augmentation</property>
+				<value>0</value>
+			</equals>
         </condition>
         <emission>
             <red-prop>instrumentation/instrumentation-light/r</red-prop>


### PR DESCRIPTION
If the afterburner switch was set to closed (so no afterburners), the 1/2/3 afterburner lights would still light up with full throttle. This fixes that, so the lights will not light up when the afterburners are switched off.