### PR TITLE
Improve loadout selection

### DIFF
--- a/Aircraft/JA37/AJ37-Viggen-set.xml
+++ b/Aircraft/JA37/AJ37-Viggen-set.xml
@@ -220,6 +220,13 @@
                             <script>armament.reloadAJAir2Air();</script>
                         </binding>
                     </item>
+					<item>
+                        <label>Reload clean</label>
+                        <binding>
+                            <command>nasal</command>
+                            <script>armament.reloadGunsOnly();</script>
+                        </binding>
+                    </item>
                     <item>
                         <label>Refuel: Standard</label>
                         <binding>

--- a/Aircraft/JA37/AJ37-Viggen-set.xml
+++ b/Aircraft/JA37/AJ37-Viggen-set.xml
@@ -490,7 +490,7 @@
         <weight n="6">
             <name>Center fuselage pylon</name>
             <weight-lb alias="/fdm/jsbsim/inertia/pointmass-weight-lbs[7]"/>
-            <selected>Drop tank</selected>
+            <selected>none</selected>
             <ammo type="int">0</ammo>
             <opt>
                 <name>none</name>

--- a/Aircraft/JA37/AJS37-Viggen-set.xml
+++ b/Aircraft/JA37/AJS37-Viggen-set.xml
@@ -219,6 +219,13 @@
                             <script>armament.reloadAJSAir2Air();</script>
                         </binding>
                     </item>
+					<item>
+                        <label>Reload clean</label>
+                        <binding>
+                            <command>nasal</command>
+                            <script>armament.reloadGunsOnly();</script>
+                        </binding>
+                    </item>
                     <item>
                         <label>Refuel: Standard</label>
                         <binding>

--- a/Aircraft/JA37/AJS37-Viggen-set.xml
+++ b/Aircraft/JA37/AJS37-Viggen-set.xml
@@ -553,7 +553,7 @@
         <weight n="6">
             <name>Center fuselage pylon</name>
             <weight-lb alias="/fdm/jsbsim/inertia/pointmass-weight-lbs[7]"/>
-            <selected>Drop tank</selected>
+            <selected>none</selected>
             <ammo type="int">0</ammo>
             <opt>
                 <name>none</name>

--- a/Aircraft/JA37/JA37-Viggen-set.xml
+++ b/Aircraft/JA37/JA37-Viggen-set.xml
@@ -520,7 +520,7 @@
         <weight n="6">
             <name>Center fuselage pylon</name>
             <weight-lb alias="/fdm/jsbsim/inertia/pointmass-weight-lbs[7]"/>
-            <selected>Drop tank</selected>
+            <selected>none</selected>
             <opt>
                 <name>none</name>
                 <lbs>0</lbs>

--- a/Aircraft/JA37/JA37-Viggen-set.xml
+++ b/Aircraft/JA37/JA37-Viggen-set.xml
@@ -244,7 +244,7 @@
                         <label>Reload guns only</label>
                         <binding>
                             <command>nasal</command>
-                            <script>armament.reloadGuns();</script>
+                            <script>armament.reloadGunsOnly();</script>
                         </binding>
                     </item>
                     <item>

--- a/Aircraft/JA37/Nasal/ja37.nas
+++ b/Aircraft/JA37/Nasal/ja37.nas
@@ -2200,6 +2200,11 @@ var refuelTest = func () {
   setprop("consumables/fuel/tank[5]/level-norm", 0.8);
   setprop("consumables/fuel/tank[6]/level-norm", 0.8);
   setprop("consumables/fuel/tank[7]/level-norm", 0.8);
+
+  # Remove drop tank
+  setprop("payload/weight[6]/selected", "none");
+  input.tank8Selected.setBoolValue(FALSE);
+  input.tank8Jettison.setBoolValue(TRUE);
   setprop("consumables/fuel/tank[8]/level-norm", 0.0);
 
   screen.log.write("Fuel configured for flight testing.", 1.0, 0.0, 0.0);
@@ -2218,6 +2223,11 @@ var refuelNorm = func () {
   setprop("consumables/fuel/tank[5]/level-norm", 1.0);
   setprop("consumables/fuel/tank[6]/level-norm", 1.0);
   setprop("consumables/fuel/tank[7]/level-norm", 1.0);
+
+  # Remove drop tank
+  setprop("payload/weight[6]/selected", "none");
+  input.tank8Selected.setBoolValue(FALSE);
+  input.tank8Jettison.setBoolValue(TRUE);
   setprop("consumables/fuel/tank[8]/level-norm", 0.0);
 
   screen.log.write("Fuel configured for standard flight.", 0.0, 1.0, 0.0);

--- a/Aircraft/JA37/Nasal/stores.nas
+++ b/Aircraft/JA37/Nasal/stores.nas
@@ -1973,6 +1973,28 @@ reloadAJSAir2Air = func {
     }
 }
 
+reloadGunsOnly = func {
+  if(getprop("payload/armament/msg") == FALSE or getprop("fdm/jsbsim/gear/unit[0]/WOW")) {
+  # Clean loadout
+  setprop("payload/weight[0]/selected", "none");
+  setprop("payload/weight[1]/selected", "none");
+  setprop("payload/weight[2]/selected", "none");
+  setprop("payload/weight[3]/selected", "none");
+  setprop("payload/weight[4]/selected", "none");
+  setprop("payload/weight[5]/selected", "none");
+  screen.log.write("Removed all stores", 0.0, 1.0, 0.0);
+
+  # Reload flares - 40 of them.
+  setprop("ai/submodels/submodel[0]/count", 60);
+  setprop("ai/submodels/submodel[1]/count", 60);
+  screen.log.write("60 flares loaded", 0.0, 1.0, 0.0);
+
+  # Reload cannon - 146 of them.
+  reloadGuns();
+} else {
+      screen.log.write(ja37.msgB);
+    }}
+
 reloadGuns = func {
   if(getprop("payload/armament/msg") == FALSE or getprop("fdm/jsbsim/gear/unit[0]/WOW")) {
   # Reload cannon - 146 of them.

--- a/Aircraft/JA37/Viggen-set-base.xml
+++ b/Aircraft/JA37/Viggen-set-base.xml
@@ -1410,7 +1410,7 @@
             </tank>
             <tank n="8">
                 <name>Drop tank</name>
-                <jettisoned type="bool">false</jettisoned>
+                <jettisoned type="bool">true</jettisoned>
             </tank>
         </fuel>
     </consumables>


### PR DESCRIPTION
Minor improvements to the quick loadout selection functions:
- The drop tank is removed when unneeded (including on simulator start)
- `Reload gun only` removes all other weapons and reload flares, instead of just reloading the gun