### PR TITLE
Fuel distributor angle limits

### DIFF
--- a/Aircraft/JA37/Systems/jsb-fuel.xml
+++ b/Aircraft/JA37/Systems/jsb-fuel.xml
@@ -163,16 +163,53 @@ TODO: manual fuel controls
 
     <channel execrate="1" name="Hydraulic fuel pumps"><!-- fuel distributor -->
 
+        <!-- The fuel distributor stops if the g-load vector is too far off the down axis.
+             Assuming no acceleration, the limits correspond to 60deg pitch, 30deg dive,
+             40deg roll left, 50deg roll right.
+        -->
+        <fcs_function name="systems/fuel/distributor-angle-limit">
+            <!-- accelerations/n-pilot-... : g-load vector, x backwards, y left, z up -->
+            <function>
+                <or>
+                    <gt>
+                        <p>accelerations/n-pilot-x-norm</p>
+                        <product>
+                            <p>accelerations/n-pilot-z-norm</p>
+                            <v>-1.73205</v> <!-- tan(60) -->
+                        </product>
+                    </gt>
+                    <lt>
+                        <p>accelerations/n-pilot-x-norm</p>
+                        <product>
+                            <p>accelerations/n-pilot-z-norm</p>
+                            <v>0.57735</v> <!-- tan(30) -->
+                        </product>
+                    </lt>
+                    <gt>
+                        <p>accelerations/n-pilot-y-norm</p>
+                        <product>
+                            <p>accelerations/n-pilot-z-norm</p>
+                            <v>-0.83910</v> <!-- tan(40) -->
+                        </product>
+                    </gt>
+                    <lt>
+                        <p>accelerations/n-pilot-y-norm</p>
+                        <product>
+                            <p>accelerations/n-pilot-z-norm</p>
+                            <v>1.19175</v> <!-- tan(50) -->
+                        </product>
+                    </lt>
+                </or>
+            </function>
+        </fcs_function>
+
         <switch name="systems/fuel/tank6-output">
             <default value="-6.89489056654767324"/>            <!-- 14500 L/h from 4V to distributor -->
             <test logic="OR" value="0">
                 propulsion/tank[6]/contents-lbs LE 0
                 propulsion/tank[0]/pct-full GE 99.9
                 structural/wings/serviceable == 0
-                /orientation/pitch-deg gt 60
-                /orientation/pitch-deg lt -30
-                /orientation/roll-deg lt -40
-                /orientation/roll-deg gt 50
+                systems/fuel/distributor-angle-limit == 1
                 systems/fuel/fuel-flow/serviceable == 0
             </test>
             <test logic="AND" value="0">
@@ -214,10 +251,7 @@ TODO: manual fuel controls
                 propulsion/tank[7]/contents-lbs LE 0
                 propulsion/tank[0]/pct-full GE 99.9
                 structural/wings/serviceable == 0
-                /orientation/pitch-deg gt 60
-                /orientation/pitch-deg lt -30
-                /orientation/roll-deg lt -40
-                /orientation/roll-deg gt 50        
+                systems/fuel/distributor-angle-limit == 1
                 systems/fuel/fuel-flow/serviceable == 0
             </test>
             <test logic="AND" value="0">
@@ -258,10 +292,7 @@ TODO: manual fuel controls
             <test logic="OR" value="0">
                 propulsion/tank[3]/contents-lbs LE 0
                 propulsion/tank[0]/pct-full GE 99.9
-                /orientation/pitch-deg gt 60
-                /orientation/pitch-deg lt -30
-                /orientation/roll-deg lt -40
-                /orientation/roll-deg gt 50
+                systems/fuel/distributor-angle-limit == 1
                 systems/fuel/fuel-flow/serviceable == 0
             </test>
             <test logic="AND" value="0">
@@ -294,10 +325,7 @@ TODO: manual fuel controls
             <test logic="OR" value="0">
                 propulsion/tank[3]/contents-lbs LE 0
                 propulsion/tank[0]/pct-full GE 99.9
-                /orientation/pitch-deg gt 60
-                /orientation/pitch-deg lt -30
-                /orientation/roll-deg lt -40
-                /orientation/roll-deg gt 50
+                systems/fuel/distributor-angle-limit == 1
                 systems/fuel/fuel-flow/serviceable == 0
             </test>
             <test logic="AND" value="0">

--- a/Aircraft/JA37/Systems/jsb-fuel.xml
+++ b/Aircraft/JA37/Systems/jsb-fuel.xml
@@ -167,49 +167,53 @@ TODO: manual fuel controls
              Assuming no acceleration, the limits correspond to 60deg pitch, 30deg dive,
              40deg roll left, 50deg roll right.
         -->
-        <fcs_function name="systems/fuel/distributor-angle-limit">
-            <!-- accelerations/n-pilot-... : g-load vector, x backwards, y left, z up -->
+
+        <!-- accelerations/n-pilot-... : g-load vector, x backwards, y left, z up -->
+
+        <!-- g-load vector direction, 0 down, 90 forward -->
+        <fcs_function name="systems/fuel/distributor/g-load-pitch-deg">
             <function>
-                <or>
-                    <gt>
-                        <p>accelerations/n-pilot-x-norm</p>
-                        <product>
-                            <p>accelerations/n-pilot-z-norm</p>
-                            <v>-1.73205</v> <!-- tan(60) -->
-                        </product>
-                    </gt>
-                    <lt>
-                        <p>accelerations/n-pilot-x-norm</p>
-                        <product>
-                            <p>accelerations/n-pilot-z-norm</p>
-                            <v>0.57735</v> <!-- tan(30) -->
-                        </product>
-                    </lt>
-                    <gt>
-                        <p>accelerations/n-pilot-y-norm</p>
-                        <product>
-                            <p>accelerations/n-pilot-z-norm</p>
-                            <v>-0.83910</v> <!-- tan(40) -->
-                        </product>
-                    </gt>
-                    <lt>
-                        <p>accelerations/n-pilot-y-norm</p>
-                        <product>
-                            <p>accelerations/n-pilot-z-norm</p>
-                            <v>1.19175</v> <!-- tan(50) -->
-                        </product>
-                    </lt>
-                </or>
+                <product>
+                    <atan2>
+                        <p>-accelerations/n-pilot-x-norm</p>
+                        <p>-accelerations/n-pilot-z-norm</p>
+                    </atan2>
+                    <v>57.29578</v> <!-- convert to deg -->
+                </product>
             </function>
         </fcs_function>
+        
+        <!-- g-load vector direction, 0 down, 90 right -->
+        <fcs_function name="systems/fuel/distributor/g-load-roll-deg">
+            <function>
+                <product>
+                    <atan2>
+                        <p>-accelerations/n-pilot-y-norm</p>
+                        <p>-accelerations/n-pilot-z-norm</p>
+                    </atan2>
+                    <v>57.29578</v> <!-- convert to deg -->
+                </product>
+            </function>
+        </fcs_function>
+        
+        <switch name="systems/fuel/distributor/angle-limit">
+            <default value="0"/>
+            <test logic="OR" value="1">
+                systems/fuel/distributor/g-load-pitch-deg LT -60
+                systems/fuel/distributor/g-load-pitch-deg GT 30
+                systems/fuel/distributor/g-load-roll-deg LT -40
+                systems/fuel/distributor/g-load-pitch-deg GT 50
+            </test>
+        </switch>
 
+        
         <switch name="systems/fuel/tank6-output">
             <default value="-6.89489056654767324"/>            <!-- 14500 L/h from 4V to distributor -->
             <test logic="OR" value="0">
                 propulsion/tank[6]/contents-lbs LE 0
                 propulsion/tank[0]/pct-full GE 99.9
                 structural/wings/serviceable == 0
-                systems/fuel/distributor-angle-limit == 1
+                systems/fuel/distributor/angle-limit == 1
                 systems/fuel/fuel-flow/serviceable == 0
             </test>
             <test logic="AND" value="0">
@@ -251,7 +255,7 @@ TODO: manual fuel controls
                 propulsion/tank[7]/contents-lbs LE 0
                 propulsion/tank[0]/pct-full GE 99.9
                 structural/wings/serviceable == 0
-                systems/fuel/distributor-angle-limit == 1
+                systems/fuel/distributor/angle-limit == 1
                 systems/fuel/fuel-flow/serviceable == 0
             </test>
             <test logic="AND" value="0">
@@ -292,7 +296,7 @@ TODO: manual fuel controls
             <test logic="OR" value="0">
                 propulsion/tank[3]/contents-lbs LE 0
                 propulsion/tank[0]/pct-full GE 99.9
-                systems/fuel/distributor-angle-limit == 1
+                systems/fuel/distributor/angle-limit == 1
                 systems/fuel/fuel-flow/serviceable == 0
             </test>
             <test logic="AND" value="0">
@@ -325,7 +329,7 @@ TODO: manual fuel controls
             <test logic="OR" value="0">
                 propulsion/tank[3]/contents-lbs LE 0
                 propulsion/tank[0]/pct-full GE 99.9
-                systems/fuel/distributor-angle-limit == 1
+                systems/fuel/distributor/angle-limit == 1
                 systems/fuel/fuel-flow/serviceable == 0
             </test>
             <test logic="AND" value="0">


### PR DESCRIPTION
My understanding is that the fuel distributor stops based on the direction of the G load vector, not the actual pitch and roll angles.

Quoting the english JA37 manual sec. 10 4.1.1.1:
- > To prevent [...] blocking of the air vent system, ...

  The air vent is at the top of the collector tank, thus it makes sense to stop the pumps during negative or highly lateral G load.
- > ... is stopped by an acceleration sensor

  The sensor measures the G load vector, which is coherent.
- > ... __corresponding__ to the following: climb >60 deg, ... [my emphasis]

  This is the weird part, I think that 'corresponding' means that 'climb >60 deg' should be interpreted as G load vector over 60 deg backwards, and so on (the two coincide when the aircraft is under no acceleration).