### PR TITLE
Lower battery discharge rate

### DIFF
--- a/Aircraft/JA37/Systems/jsb-electric.xml
+++ b/Aircraft/JA37/Systems/jsb-electric.xml
@@ -519,11 +519,11 @@
             <description>
                       DC voltage output
             </description>
-            <default value="0.0004"/>
-            <test logic="OR" value="0.001666">
+            <default value="0.000004"/>        <!-- ~3 days when fully stopped  -->
+            <test logic="OR" value="0.001666"> <!-- ~10 min when supplying DC systems -->
                 systems/electrical/rectifiers-output lt systems/electrical/battery-to-main
             </test>
-            <test logic="AND" value="0.0006">
+            <test logic="AND" value="0.00004"> <!-- ~7 hours under normal operation  -->
                 systems/electrical/relay-lr-1 == 1
             </test>
         </switch>


### PR DESCRIPTION
Currently the battery discharges in less than 30min under normal operation. This is problematic because the battery stops charging 50min after the generator comes online, and thus dies after a bit more than 1 hour of flight.

New discharge rates:
- Discharge in ~3 days when fully stopped (from 40min). This is probably still very short, but sufficient for a simulator.
- Discharge in ~7 hours under normal operation, i.e. with the rectifiers supplying DC current, and the battery unused (from 30min).
- Discharge in 10 min under load (unchanged).

The new values seem more sensible to me but are complete guesses, please tell me if you think they should be adjusted either way.