### PR TITLE
Fix pedals movement direction

### DIFF
--- a/Aircraft/JA37/Models/Cockpit/rudder_pedals.xml
+++ b/Aircraft/JA37/Models/Cockpit/rudder_pedals.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 
 <PropertyList>
 
@@ -14,7 +14,7 @@
         <type>translate</type>
         <object-name>Pedal.1</object-name>
         <property>fdm/jsbsim/fcs/rudder/input</property>
-        <factor>0.06</factor>
+        <factor>-0.06</factor>
         <axis>
             <x>1.0</x>
             <y>0.0</y>
@@ -43,7 +43,7 @@
         <type>translate</type>
         <object-name>Pedal.2</object-name>
         <property>fdm/jsbsim/fcs/rudder/input</property>
-        <factor>-0.06</factor>
+        <factor>0.06</factor>
         <axis>
             <x>1.0</x>
             <y>0.0</y>


### PR DESCRIPTION
Unless the Viggen is different from every other aircraft, the pedals movements were inverted.