### PR TITLE
Remove all 'userarchive' attributes

### DIFF
--- a/Aircraft/JA37/AJ37-Viggen-set.xml
+++ b/Aircraft/JA37/AJ37-Viggen-set.xml
@@ -850,7 +850,7 @@
             <variant type="int">1</variant>
         </systems> 
         <effect>
-            <g-suit userarchive="y" type="int">1</g-suit><!-- 1:71 2:79 3:97 -->       
+            <g-suit type="int">1</g-suit><!-- 1:71 2:79 3:97 -->
         </effect>
     </ja37>
 

--- a/Aircraft/JA37/AJS37-Viggen-set.xml
+++ b/Aircraft/JA37/AJS37-Viggen-set.xml
@@ -1028,7 +1028,7 @@
             <variant type="int">2</variant>
         </systems>
         <effect>
-            <g-suit userarchive="y" type="int">2</g-suit><!-- 1:71 2:79 3:97 -->       
+            <g-suit type="int">2</g-suit><!-- 1:71 2:79 3:97 -->
         </effect>
     </ja37>
 

--- a/Aircraft/JA37/JA37-Viggen-set.xml
+++ b/Aircraft/JA37/JA37-Viggen-set.xml
@@ -947,7 +947,7 @@
             <KV1 type="string">channel-selector-ja.png</KV1>
         </texture>
         <effect>
-            <g-suit userarchive="y" type="int">2</g-suit><!-- 1:71 2:79 3:97 -->       
+            <g-suit type="int">2</g-suit><!-- 1:71 2:79 3:97 -->
         </effect>
     </ja37>
 

--- a/Aircraft/JA37/Viggen-set-base.xml
+++ b/Aircraft/JA37/Viggen-set-base.xml
@@ -159,14 +159,14 @@
         </current-view>
 
         <view n="0">
-            <internal userarchive="n">true</internal>
+            <internal>true</internal>
             <config>
-                <pitch-offset-deg type="double" userarchive="n">-25.75</pitch-offset-deg>
-                <x-offset-m type="double" userarchive="n">0</x-offset-m>
-                <y-offset-m type="double" userarchive="n">0.74</y-offset-m>
+                <pitch-offset-deg type="double">-25.75</pitch-offset-deg>
+                <x-offset-m type="double">0</x-offset-m>
+                <y-offset-m type="double">0.74</y-offset-m>
                 <!-- remember to change eyepoint in JSB when changing this -->
-                <z-offset-m type="double" userarchive="n">-3.6</z-offset-m>
-                <default-field-of-view-deg type="double" userarchive="n">90</default-field-of-view-deg><!-- when changing this, change it in ja37.nas also -->
+                <z-offset-m type="double">-3.6</z-offset-m>
+                <default-field-of-view-deg type="double">90</default-field-of-view-deg><!-- when changing this, change it in ja37.nas also -->
             </config>
         </view>
         <!--<view n="100">
@@ -337,7 +337,7 @@
 *************************************************************************-->
         <rendering>
             <redout>
-                <enabled type="bool" userarchive="n" archive="n">true</enabled>
+                <enabled type="bool" archive="n">true</enabled>
                 <parameters>
                     <blackout-onset-g type="double">5</blackout-onset-g>
                     <blackout-complete-g type="double">8</blackout-complete-g>
@@ -611,12 +611,12 @@
         <hud>
             <tracks-enabled type="bool">true</tracks-enabled>
             <units-metric type="bool">false</units-metric>
-            <mode userarchive="y" type="bool">true</mode>
+            <mode type="bool">true</mode>
             <current-mode type="int">0</current-mode>
             <combat type="bool">false</combat>
             <bank-indicator type="bool">false</bank-indicator>
             <callsign type="bool">true</callsign>
-            <stroke-linewidth userarchive="y" type="double">5.0</stroke-linewidth>
+            <stroke-linewidth type="double">5.0</stroke-linewidth>
             <TILS type="bool">true</TILS>
             <TILS-on type="bool">false</TILS-on>
             <landing-mode type="bool">false</landing-mode>
@@ -723,7 +723,7 @@
         </avionics>
         <displays>
             <show-full-menus type="bool">true</show-full-menus>
-            <live-map userarchive="y" type="bool">true</live-map>
+            <live-map type="bool">true</live-map>
             <ti-contrast type="double">1.25</ti-contrast>
         </displays>
         <systems>
@@ -759,18 +759,18 @@
             </fr31>
         </radio>
         <faf>
-            <friend-1 userarchive="y" type="string"></friend-1>
-            <friend-2 userarchive="y" type="string"></friend-2>
-            <friend-3 userarchive="y" type="string"></friend-3>
-            <friend-4 userarchive="y" type="string"></friend-4>
-            <friend-5 userarchive="y" type="string"></friend-5>
-            <friend-6 userarchive="y" type="string"></friend-6>
-            <foe-1 userarchive="y" type="string"></foe-1>
-            <foe-2 userarchive="y" type="string"></foe-2>
-            <foe-3 userarchive="y" type="string"></foe-3>
-            <foe-4 userarchive="y" type="string"></foe-4>
-            <foe-5 userarchive="y" type="string"></foe-5>
-            <foe-6 userarchive="y" type="string"></foe-6>
+            <friend-1 type="string"></friend-1>
+            <friend-2 type="string"></friend-2>
+            <friend-3 type="string"></friend-3>
+            <friend-4 type="string"></friend-4>
+            <friend-5 type="string"></friend-5>
+            <friend-6 type="string"></friend-6>
+            <foe-1 type="string"></foe-1>
+            <foe-2 type="string"></foe-2>
+            <foe-3 type="string"></foe-3>
+            <foe-4 type="string"></foe-4>
+            <foe-5 type="string"></foe-5>
+            <foe-6 type="string"></foe-6>
         </faf>
         <navigation>
             <inout type="bool">true</inout>
@@ -858,10 +858,10 @@
                 <flare-release-out-snd type="bool">false</flare-release-out-snd>
             </submodel>
             <submodel n="2">
-                <random userarchive="y" type="bool">false</random>
+                <random type="bool">false</random>
             </submodel>
             <submodel n="3">
-                <random userarchive="y" type="bool">false</random>
+                <random type="bool">false</random>
             </submodel>
         </submodels>
     </ai>
@@ -1223,24 +1223,24 @@
         <damage-smoke type="bool">false</damage-smoke>
         <star-magnitude-cutoff type="float">6.5</star-magnitude-cutoff>
         <aircraft-effects>
-            <splash-vector-x type="float" userarchive="n">0.0</splash-vector-x>
-            <splash-vector-y type="float" userarchive="n">0.1</splash-vector-y>
-            <splash-vector-z type="float" userarchive="n">1.0</splash-vector-z>
-            <frost-level type="float" userarchive="n">0.0</frost-level>
-            <fog-level type="float" userarchive="n">0.0</fog-level>
-            <ground-splash-norm type="float" userarchive="n">0.0</ground-splash-norm>
-            <use-wipers type="int" userarchive="n">0</use-wipers>
-            <use-overlay type="int" userarchive="n">0</use-overlay>
-            <overlay-alpha type="float" userarchive="n">1.0</overlay-alpha>
-            <use-mask type="int" userarchive="n">0</use-mask>
-            <dewpoint-inside-degC type="float" userarchive="n">0.0</dewpoint-inside-degC>
-            <temperature-inside-degC type="float" userarchive="n">15.0</temperature-inside-degC>
-            <temperature-glass-degC type="float" userarchive="n">15.0</temperature-glass-degC>
-            <glass-temperature-index type="float" userarchive="n">0.51</glass-temperature-index>
-            <fog-inside type="float" userarchive="n">0.0</fog-inside>
-            <fog-outside type="float" userarchive="n">0.0</fog-outside>
-            <frost-inside type="float" userarchive="n">0.0</frost-inside>
-            <frost-outside type="float" userarchive="n">0.0</frost-outside>
+            <splash-vector-x type="float">0.0</splash-vector-x>
+            <splash-vector-y type="float">0.1</splash-vector-y>
+            <splash-vector-z type="float">1.0</splash-vector-z>
+            <frost-level type="float">0.0</frost-level>
+            <fog-level type="float">0.0</fog-level>
+            <ground-splash-norm type="float">0.0</ground-splash-norm>
+            <use-wipers type="int">0</use-wipers>
+            <use-overlay type="int">0</use-overlay>
+            <overlay-alpha type="float">1.0</overlay-alpha>
+            <use-mask type="int">0</use-mask>
+            <dewpoint-inside-degC type="float">0.0</dewpoint-inside-degC>
+            <temperature-inside-degC type="float">15.0</temperature-inside-degC>
+            <temperature-glass-degC type="float">15.0</temperature-glass-degC>
+            <glass-temperature-index type="float">0.51</glass-temperature-index>
+            <fog-inside type="float">0.0</fog-inside>
+            <fog-outside type="float">0.0</fog-outside>
+            <frost-inside type="float">0.0</frost-inside>
+            <frost-outside type="float">0.0</frost-outside>
         </aircraft-effects>
         <precipitation-control>
             <clip-distance type="double">1.75</clip-distance>


### PR DESCRIPTION
This is related to the discussion about garbage multiplayer properties on the fg-devel mailing list.

There were a few properties with attribute `userachive="y"`. This is redundant because they are also in `<aircraft-data>`, which seems more appropriate since it uses an aircraft specific path.
I removed them, as well as some `userarchive="n"`, which (correct me if I am wrong) do nothing.