### PR TITLE
Doppler for JA radar

### DIFF
--- a/Aircraft/JA37/Nasal/radar/radar-logic.nas
+++ b/Aircraft/JA37/Nasal/radar/radar-logic.nas
@@ -295,9 +295,10 @@ var RadarLogic = {
           var visible = FALSE;
           if(track.getName() == "rb-99") {
               visible = TRUE; # datalink
-          } elsif(rcs.inRadarRange(me.contact, 40, 3.2)) {
-              # Needs a ground radar to see SURFACE and MARINE contacts.
-              visible = (groundRadar or type == AIR or type == ORDNANCE);
+          } else {
+              var type = me.trackInfo.get_type();
+              visible = ((groundRadar or type == AIR or type == ORDNANCE)
+                         and rcs.inRadarRange(me.trackInfo, 40, 3.2));
           }
 
           if (visible) {

--- a/Aircraft/JA37/Nasal/radar/radar-logic.nas
+++ b/Aircraft/JA37/Nasal/radar/radar-logic.nas
@@ -307,37 +307,15 @@ var RadarLogic = {
           if (!missile) {
             append(complete_list, me.trackInfo);
           }
-          if(1==0 and selection == nil and getprop("ja37/avionics/cursor-on") != FALSE) {
-            #this is first tracks in radar field, so will be default selection
+
+          if (selection != nil and selection.getUnique() == me.unique.getValue() and visible) {
             selection = me.trackInfo;
-            lookatSelection();
-            selection_updated = TRUE;
-            #if (selection.get_type() == AIR) {
-              me.paint(selection.getNode(), TRUE);
-            #} else {
-            #  me.paint(selection.getNode(), FALSE);
-            #}
-          #} elsif (track.getChild("name") != nil and track.getChild("name").getValue() == "RB-24J") {
-            #for testing that selection view follows missiles
-          #  selection = trackInfo;
-          #  lookatSelection();
-          #  selection_updated = TRUE;
-          } elsif (selection != nil and selection.getUnique() == me.unique.getValue()) {
-            # this track is already selected, updating it
-            #print("updating target");
-            selection = me.trackInfo;
-            #if (selection.get_type() == AIR) {
-              me.paint(selection.getNode(), TRUE);
-            #} else {
-            #  me.paint(selection.getNode(), FALSE);
-            #}
+            me.paint(selection.getNode(), TRUE);
             selection_updated = TRUE;
           } else {
-            #print("end2 "~selection.getUnique()~"=="~unique.getValue());
             me.paint(me.trackInfo.getNode(), FALSE);
           }
         } else {
-          #print("end");
           me.paint(track, FALSE);
         }
   #});      

--- a/Aircraft/JA37/Nasal/radar/radar-logic.nas
+++ b/Aircraft/JA37/Nasal/radar/radar-logic.nas
@@ -196,12 +196,16 @@ var RadarLogic = {
           me.paint(selection.getNode(), FALSE);
         }
         selection = nil;
-        steerOrder = FALSE;
+        disableSteerOrder();
         setprop("ja37/radar/active" , FALSE);
       }
       if(selection != nil and selection_updated == FALSE and selection.parents[0] != radar_logic.ContactGPS) {
+        # Lost lock
+        if(selection != nil) {
+          me.paint(selection.getNode(), FALSE);
+        }
+        selection = nil;
         disableSteerOrder();
-        #append(selection, "lock");
       }
   },
 


### PR DESCRIPTION
Enable doppler code for JA, that is the radar will not pick up contacts classified as ground contacts.
The AJ(S) should be unaffected.

I will keep the PR open while testing.

Minor fixes:
- Traverse speed should not affect doppler
- Radar no longer remembers selection after lost lock