### PR TITLE
Various radar stuff

### DIFF
--- a/Aircraft/JA37/Nasal/displays/ti.nas
+++ b/Aircraft/JA37/Nasal/displays/ti.nas
@@ -1673,10 +1673,6 @@ var TI = {
 		ti.showHostileZones = TRUE;
 		ti.showFriendlyZones = TRUE;
 		
-		# radar echoes overlay
-		ti.foes    = [];
-		ti.friends = [];
-		
 		# rwr overlay
 		ti.ECMon   = FALSE;
 		
@@ -1771,7 +1767,6 @@ var TI = {
 		me.showMapScale();
 		me.updateSVY();# must be before displayRadarTracks and showselfvector
 		me.showSelfVector();
-		me.defineEnemies();# must be before displayRadarTracks
 		me.displayRadarTracks();
 		me.showRunway();
 		me.showRadarLimit();
@@ -4752,11 +4747,6 @@ var TI = {
 		}
 	},
 
-	defineEnemies: func {
-		me.foes    = [getprop("ja37/faf/foe-1"),getprop("ja37/faf/foe-2"),getprop("ja37/faf/foe-3"),getprop("ja37/faf/foe-4"),getprop("ja37/faf/foe-5"),getprop("ja37/faf/foe-6")];
-		me.friends = [getprop("ja37/faf/friend-1"),getprop("ja37/faf/friend-2"),getprop("ja37/faf/friend-3"),getprop("ja37/faf/friend-4"),getprop("ja37/faf/friend-5"),getprop("ja37/faf/friend-6")];
-	},
-
 	displayRadarTracks: func () {
 
 		me.threatIndex  = -1;
@@ -4848,11 +4838,11 @@ var TI = {
 		    me.tgtSpeed = contact.get_Speed();
 		    me.myHeading = me.input.headTrue.getValue();
 		    me.boogie = 0;
-		    if (containsVector(me.friends, contact.get_Callsign())) {
+		    if (faf.is_friend(contact.get_Callsign())) {
 	    		me.boogie = 1;
-	    	} elsif (containsVector(me.foes, contact.get_Callsign())) {
+		    } elsif (faf.is_foe(contact.get_Callsign())) {
 	    		me.boogie = -1;
-	    	}
+		    }
 
 		    if (me.currentIndexT == 0 and contact.parents[0] == radar_logic.ContactGPS) {
 		    	me.gpsSymbol.setTranslation(me.pos_xx, me.pos_yy);

--- a/Aircraft/JA37/Nasal/displays/ti.nas
+++ b/Aircraft/JA37/Nasal/displays/ti.nas
@@ -1294,10 +1294,15 @@ var TI = {
 		me.ecmRadius = 50;
 		me.ecm = [];
 	    append(me.ecm, me.ecm_grp.createChild("path")
+			.moveTo(circlePosH(-14, me.ecmRadius)[0], circlePosH(-14, me.ecmRadius)[1])
+	        .arcSmallCW(me.ecmRadius, me.ecmRadius, 0, circlePosH(14, me.ecmRadius)[0]-circlePosH(-14, me.ecmRadius)[0], circlePosH(14, me.ecmRadius)[1]-circlePosH(-14, me.ecmRadius)[1])
+	        .setStrokeLineWidth(w*10)
+	        .setColor(COLOR_YELLOW));
+	    append(me.ecm, me.ecm_grp.createChild("path")
 			.moveTo(circlePosH(16, me.ecmRadius)[0], circlePosH(16, me.ecmRadius)[1])
 	        .arcSmallCW(me.ecmRadius, me.ecmRadius, 0, circlePosH(44, me.ecmRadius)[0]-circlePosH(16, me.ecmRadius)[0], circlePosH(44, me.ecmRadius)[1]-circlePosH(16, me.ecmRadius)[1])
 	        .setStrokeLineWidth(w*10)
-	        .setColor(COLOR_RED));
+	        .setColor(COLOR_YELLOW));
 	    append(me.ecm, me.ecm_grp.createChild("path")
 			.moveTo(circlePosH(46, me.ecmRadius)[0], circlePosH(46, me.ecmRadius)[1])
 	        .arcSmallCW(me.ecmRadius, me.ecmRadius, 0, circlePosH(74, me.ecmRadius)[0]-circlePosH(46, me.ecmRadius)[0], circlePosH(74, me.ecmRadius)[1]-circlePosH(46, me.ecmRadius)[1])
@@ -1348,11 +1353,6 @@ var TI = {
 	        .arcSmallCW(me.ecmRadius, me.ecmRadius, 0, circlePosH(344, me.ecmRadius)[0]-circlePosH(316, me.ecmRadius)[0], circlePosH(344, me.ecmRadius)[1]-circlePosH(316, me.ecmRadius)[1])
 	        .setStrokeLineWidth(w*10)
 	        .setColor(COLOR_YELLOW));
-	    append(me.ecm, me.ecm_grp.createChild("path")
-			.moveTo(circlePosH(-14, me.ecmRadius)[0], circlePosH(-14, me.ecmRadius)[1])
-	        .arcSmallCW(me.ecmRadius, me.ecmRadius, 0, circlePosH(14, me.ecmRadius)[0]-circlePosH(-14, me.ecmRadius)[0], circlePosH(14, me.ecmRadius)[1]-circlePosH(-14, me.ecmRadius)[1])
-	        .setStrokeLineWidth(w*10)
-	        .setColor(COLOR_GREEN));
 
 		# small airports
 		me.baseSmallText = [];
@@ -3296,14 +3296,11 @@ var TI = {
 
 	ecmOverlay: func {
 		if (me.ECMon == TRUE) {
-			for (me.ijk =0;me.ijk<12;me.ijk+=1) {
-				if (getprop("ja37/sound/incoming"~(me.ijk+1)) == TRUE) {
-					me.ecm[me.ijk].setColor(COLOR_RED);
-				} elsif (radar_logic.rwr[me.ijk] == TRUE) {
-					me.ecm[me.ijk].setColor(COLOR_YELLOW);
-				} else {
-					me.ecm[me.ijk].setColor(COLOR_GREEN_DARK);
-				}
+			for (var i=0; i<12; i+=1) {
+				var signal = rwr.get_highest_signal(i);
+				if(signal >= rwr.RWR_LOCK) me.ecm[i].setColor(COLOR_RED);
+				elsif(signal >= rwr.RWR_SCAN) me.ecm[i].setColor(COLOR_YELLOW);
+				else me.ecm[i].setColor(COLOR_GREEN_DARK);
 			}
 			me.ecm_grp.show();
 		} else {

--- a/Aircraft/JA37/Nasal/failure/damage.nas
+++ b/Aircraft/JA37/Nasal/failure/damage.nas
@@ -169,6 +169,10 @@ var incoming_listener = func {
                 #print("bearing to enemy found");
                 var bearing = bearingNode.getValue();
                 var heading = getprop("orientation/heading-deg");
+                # Send a signal to RWR. First argument is an UID, needed to update the signal.
+                # Since we will never update it, just generate a new UID and forget it.
+                rwr.signal(rand(), rwr.RWR_LAUNCH, bearing - heading);
+
                 var clock = bearing - heading;
                 while(clock < 0) {
                   clock = clock + 360;
@@ -209,7 +213,7 @@ var incoming_listener = func {
                 #The incoming CI lamps overlap each other:
                 if (clock >= 345 or clock <= 75) {
                   incomingLamp("1");
-                } 
+                }
                 if (clock >= 45 and clock <= 135) {
                   incomingLamp("3");
                 }

--- a/Aircraft/JA37/Nasal/radar/faf.nas
+++ b/Aircraft/JA37/Nasal/radar/faf.nas
@@ -1,0 +1,33 @@
+# Keep a list of friends/foes from a node (/ja37/faf/) with children friend[i] and foe[i]
+
+var friends = {};
+var foes = {};
+
+var faf_node = props.globals.getNode("ja37/faf", 1);
+
+
+var is_friend = func(callsign) {
+    return contains(friends, callsign);
+}
+
+var is_foe = func(callsign) {
+    return contains(foes, callsign);
+}
+
+
+var update_lists = func() {
+    # Re-read the entire lists if an update is needed.
+    # This is lazy coding, but it's not like the lists are changed frequently.
+    friends = {};
+    foreach(friend; faf_node.getNode("friends", 1).getChildren("friend")) {
+        var callsign = friend.getValue();
+        if(callsign != "") friends[callsign] = 1;
+    }
+    foes = {};
+    foreach(foe; faf_node.getNode("foes", 1).getChildren("foe")) {
+        var callsign = foe.getValue();
+        if(callsign != "") foes[callsign] = 1;
+    }
+}
+
+setlistener(faf_node, update_lists, 1, 2);

--- a/Aircraft/JA37/Nasal/radar/radar-logic.nas
+++ b/Aircraft/JA37/Nasal/radar/radar-logic.nas
@@ -82,14 +82,24 @@ var MARINE = 1;
 var SURFACE = 2;
 var ORDNANCE = 3;
 
-var knownShips = {
-    "missile_frigate":       nil,
-    "frigate":       nil,
-    "fleet":       nil,
-    "USS-LakeChamplain":     nil,
-    "USS-NORMANDY":     nil,
-    "USS-OliverPerry":     nil,
-    "USS-SanAntonio":     nil,
+var knownTypes = {
+    "missile_frigate":    MARINE,
+    "frigate":            MARINE,
+    "fleet":              MARINE,
+    "USS-LakeChamplain":  MARINE,
+    "USS-NORMANDY":       MARINE,
+    "USS-OliverPerry":    MARINE,
+    "USS-SanAntonio":     MARINE,
+    "buk-m2":             SURFACE,
+    "s-300":              SURFACE,
+    "depot":              SURFACE,
+    "struct":             SURFACE,
+    "rig":                MARINE,
+    "point":              SURFACE,
+    "gci":                SURFACE,
+    "hunter":             SURFACE,
+    "truck":              SURFACE,
+    "tower":              SURFACE,
 };
 
 var input = {
@@ -422,8 +432,8 @@ var RadarLogic = {
 
   # Try to guess the type of contact. This is not very reliable.
   guessType: func (track, trackPos, model) {
-    # To help with classification, some ship models are hard-coded.
-    if(contains(knownShips, model)) return MARINE;
+    # To help with classification, some models are hard-coded
+    if(contains(knownTypes, model)) return knownTypes[model];
 
     # Assume that anything fast is an air target - we don't have many racing cars.
     if(track.getValue("velocities/true-airspeed-kt") > 50) return AIR;

--- a/Aircraft/JA37/Nasal/radar/radar-logic.nas
+++ b/Aircraft/JA37/Nasal/radar/radar-logic.nas
@@ -443,7 +443,7 @@ var RadarLogic = {
         # Ground info below the target, allows a reasonably precise classification.
         var AGL = trackPos.alt() - ground[0];
         if(AGL > 10) return AIR;
-        elsif(!ground[1].solid) return MARINE; # On water
+        elsif(ground[1] != nil and !ground[1].solid) return MARINE; # On water
         else return SURFACE;
     } else {
         if(trackPos.alt() < 3) return MARINE;

--- a/Aircraft/JA37/Nasal/radar/radar-logic.nas
+++ b/Aircraft/JA37/Nasal/radar/radar-logic.nas
@@ -82,6 +82,7 @@ var MARINE = 1;
 var SURFACE = 2;
 var ORDNANCE = 3;
 
+# Hard coded table to help with target classification
 var knownTypes = {
     "missile_frigate":    MARINE,
     "frigate":            MARINE,
@@ -100,6 +101,21 @@ var knownTypes = {
     "hunter":             SURFACE,
     "truck":              SURFACE,
     "tower":              SURFACE,
+};
+
+# The following models are completely ignored
+var ignoreModels = {
+    # Backseat models
+    "f-14b-bs": nil,
+    "f15-bs": nil,
+    "m2000-5B-backseat": nil,
+    # ATC
+    "ATC-pie": nil,
+    "Openradar": nil,
+    # Anyone still uses these?
+    "atc-tower": nil,
+    "atc-tower2": nil,
+    "ATC-ML": nil,
 };
 
 var input = {
@@ -234,10 +250,12 @@ var RadarLogic = {
 
       # Read, or compute and store the simplified model name and UID
       var model = me.getModelShorter(track);
+      if (model != nil and contains(ignoreModels, model)) continue;
+
       var UID = me.getUID(track);
 
       var trackPos = me.getTrackPos(track);
-      if(trackPos == nil) continue;
+      if (trackPos == nil) continue;
 
       # For MP aircrafts, we must guess the type of the contact
       var track_type = type;
@@ -433,7 +451,7 @@ var RadarLogic = {
   # Try to guess the type of contact. This is not very reliable.
   guessType: func (track, trackPos, model) {
     # To help with classification, some models are hard-coded
-    if(contains(knownTypes, model)) return knownTypes[model];
+    if(model != nil and contains(knownTypes, model)) return knownTypes[model];
 
     # Assume that anything fast is an air target - we don't have many racing cars.
     if(track.getValue("velocities/true-airspeed-kt") > 50) return AIR;

--- a/Aircraft/JA37/Nasal/radar/radar-logic.nas
+++ b/Aircraft/JA37/Nasal/radar/radar-logic.nas
@@ -402,7 +402,15 @@ var RadarLogic = {
     # Currently, ground radars are magic.
     if(!groundRadar and !me.doppler(trackPos, track)) return FALSE;
     # Finally RCS check
-    return rcs.inRadarRange(trackInfo, 40, 3.2);
+    if(selection != nil and selection.getUnique() == trackInfo.getUnique()) {
+      # This function will always redo the RCS test, for better accuracy
+      # for the target being tracked (see below).
+      return rcs.isInRadarRange(trackInfo, 40, 3.2);
+    } else {
+      # For other tracks, this function caches the results for a few
+      # seconds, for performance.
+      return rcs.inRadarRange(trackInfo, 40, 3.2);
+    }
   },
 
   # Checks that the track is within the radar angle limits

--- a/Aircraft/JA37/Nasal/radar/radar-logic.nas
+++ b/Aircraft/JA37/Nasal/radar/radar-logic.nas
@@ -6,8 +6,13 @@ var rad2deg = 180.0/math.pi;
 var kts2kmh = 1.852;
 var feet2meter = 0.3048;
 var round0 = func(x) { return math.abs(x) > 0.01 ? x : 0; };
-var radarRange = getprop("ja37/systems/variant") == 0?120000:120000;#meter
-var groundRadar = (getprop("ja37/systems/variant") != 0);
+var is_ja = (getprop("ja37/systems/variant") == 0);
+var maxRadarRange = 120000; #meters
+var radarRange = maxRadarRange;
+var rwrRange = 180000;
+var groundRadar = !is_ja;
+# Aircrafts beyond that range will be entirely ignored
+var ignoreRange = math.max(radarRange, rwrRange);
 
 var containsVector = func (vec, item) {
   foreach(test; vec) {
@@ -28,6 +33,14 @@ var containsVectorIndex = func (vec, item) {
   }
   return -1;
 }
+
+var remove_suffix = func(str, suffix) {
+  var len = size(suffix);
+  if (substr(str, -len) == suffix) return substr(str, 0, size(str) - len);
+  else return str;
+};
+
+
 
 var getClock = func (bearing) {
     var clock = int(((geo.normdeg(bearing)-15)/30)+1);
@@ -99,6 +112,7 @@ var input = {
         alt_ft:           "instrumentation/altimeter/indicated-altitude-ft",
         alt_true_ft:      "position/altitude-ft",
         radar_serv:       "instrumentation/radar/serviceable",
+        radar_range:      "instrumentation/radar/range",
         hdgReal:          "/orientation/heading-deg",
         pitch:            "/orientation/pitch-deg",
         roll:             "/orientation/roll-deg",
@@ -131,6 +145,7 @@ var RadarLogic = {
       myRoll    =  input.roll.getValue()*D2R;
       myAlt     =  self.alt();
       myHeading =  input.hdgReal.getValue();
+      radarRange = input.radar_range.getValue();
       selection_updated = FALSE;
       
       tracks = [];
@@ -221,286 +236,208 @@ var RadarLogic = {
 
   processTracks: func (vector, carrier, missile = 0, mp = 0, type = -1) {
     foreach (var track; vector) {
-      if(track != nil and track.getChild("valid") != nil and track.getChild("valid").getValue() == TRUE) {#only the tracks that are valid are sent here
-        me.trackInfo = nil;
-  #debug.benchmark("radar trackitemcalc", func {
-        if(missile == FALSE) {
-          me.trackInfo = me.trackItemCalc(track, getprop("instrumentation/radar/range"), carrier, mp, type);
-        } else {
-          me.trackInfo = me.trackMissileCalc(track, getprop("instrumentation/radar/range"), carrier, mp, type);
-        }
-  #});
-  #debug.benchmark("radar process", func {
-        if(me.trackInfo != nil) {
-          me.distance = me.trackInfo.get_range()*NM2M;
+      # Filter out invalid tracks
+      if (track == nil or track.getChild("valid") == nil or !track.getChild("valid").getBoolValue()) continue;
 
-          # find and remember the type of the track
-          me.typeNode = track.getChild("model-shorter");
-          me.model = nil;
-          if (me.typeNode != nil) {
-            me.model = me.typeNode.getValue();
-          } else {
-            me.pathNode = track.getNode("sim/model/path");
-            if (me.pathNode != nil) {
-              me.path = me.pathNode.getValue();
-              me.model = split(".", split("/", me.path)[-1])[0];
+      # Read, or compute and store the simplified model name and UID
+      var model = me.getModelShorter(track);
+      var UID = me.getUID(track);
 
-              me.model = me.remove_suffix(me.model, "-model");
-              me.model = me.remove_suffix(me.model, "-anim");
-              track.addChild("model-shorter").setValue(me.model);
+      var trackPos = me.getTrackPos(track);
+      if(trackPos == nil) continue;
 
-              var funcHash = {
-                new: func (trackN, pNode) {
-                  me.listenerID1 = setlistener(trackN.getChild("valid"), func me.callme1(), nil, 1);
-                  me.listenerID2 = setlistener(pNode,                    func me.callme2(), nil, 1);
-                },
-                callme1: func () {
-                  if(me.trackme.getChild("valid").getValue() == FALSE) {
-                    var child = me.trackme.removeChild("model-shorter",0);#index 0 must be specified!
-                    if (child != nil) {#for some reason this can be called two times, even if listener removed, therefore this check.
-                      me.del();
-                    }
-                  }
-                },
-                callme2: func () {
-                  if(me.trackme.getNode("sim/model/path") == nil or funcHash.trackme.getNode("sim/model/path").getValue() != me.oldpath) {
-                    var child = me.trackme.removeChild("model-shorter",0);
-                    if (child != nil) {#for some reason this can be called two times, even if listener removed, therefore this check.
-                      me.del();
-                    }
-                  }
-                },
-                del: func () {
-                  removelistener(me.listenerID1);
-                  removelistener(me.listenerID2);
-                  radar_logic.radarLogic.typeHashes[me.trackme.getPath()] = nil;
-                },
-              };
-              
-              funcHash.trackme = track;
-              funcHash.oldpath = me.path;
+      # For MP aircrafts, we must guess the type of the contact
+      var track_type = type;
+      if (track_type == -1) {
+        track_type = me.guessType(track, trackPos, model);
+      }
 
-              me.typeHashes[track.getPath()] = funcHash;
+      ## The track node is valid, start actual processing
+      var trackInfo = Contact.new(track, track_type);
 
-              funcHash.new(track, me.pathNode);
-            }
-          }
+      # Unpaint the contact a priori.
+      me.paint(track, FALSE);
 
-          me.unique = track.getChild("unique");
-          if (me.unique == nil) {
-            me.unique = track.addChild("unique");
-            me.unique.setDoubleValue(rand());
-          }
+      # Check range
+      var distance = self.direct_distance_to(trackPos);
+      if (distance > ignoreRange) continue;
 
-          var visible = FALSE;
-          if(track.getName() == "rb-99") {
-              visible = TRUE; # datalink
-          } else {
-              var type = me.trackInfo.get_type();
-              visible = ((groundRadar or type == AIR or type == ORDNANCE)
-                         and rcs.inRadarRange(me.trackInfo, 40, 3.2));
-          }
+      # Remember all tracks in this list, before we start filtering out hidden ones.
+      if (!missile) append(complete_list, trackInfo);
 
-          if (visible) {
-            append(tracks, me.trackInfo);
-          }
-          if (!missile) {
-            append(complete_list, me.trackInfo);
-          }
+      # Line of sight
+      if (mp or getprop("ja37/supported/picking")) {
+        # is multiplayer or 2017.2.1+
+        if (!me.isNotBehindTerrain(trackPos)) continue; # no sight
+      }
 
-          if (selection != nil and selection.getUnique() == me.unique.getValue() and visible) {
-            selection = me.trackInfo;
-            me.paint(selection.getNode(), TRUE);
-            selection_updated = TRUE;
-          } else {
-            me.paint(me.trackInfo.getNode(), FALSE);
-          }
-        } else {
-          me.paint(track, FALSE);
-        }
-  #});      
-      }#end of valid check
+      # RWR
+      if (mp and is_ja and TI.ti.ECMon and distance <= rwrRange and me.isRWRActive(trackPos, track)) {
+        var clock = getClock(self.course_to(trackPos) - myHeading);
+        rwr[clock-1] = TRUE;
+      }
+
+      # Rest is for radar only
+      if (!me.isRadarVisible(track, trackInfo, trackPos, distance)) continue;
+
+      append(tracks, trackInfo);
+
+      # Keep track of selected target
+      if (selection != nil and selection.getUnique() == UID) {
+        selection = trackInfo;
+        me.paint(track, TRUE);
+        selection_updated = TRUE;
+      }
     }#end of foreach
   },#end of processTracks
 
+  getTrackPos: func(track) {
+    var posNode = track.getChild("position");
+    if (posNode.getChild("global-x") != nil) {
+      return geo.Coord.new().set_xyz(
+        posNode.getValue("global-x"),
+        posNode.getValue("global-y"),
+        posNode.getValue("global-z"));
+    } else {
+      return geo.Coord.new().set_latlon(
+        posNode.getValue("latitude-deg"),
+        posNode.getValue("longitude-deg"),
+        posNode.getValue("altitude-ft")*FT2M);
+    }
+  },
+
+  getModelShorter: func(track) {
+    var model = track.getValue("model-shorter");
+    if(model != nil) return model;
+
+    var pathNode = track.getNode("sim/model/path");
+    if(pathNode == nil) return nil;
+    model = split(".", split("/", pathNode.getValue())[-1])[0];
+    model = remove_suffix(model, "-model");
+    model = remove_suffix(model, "-anim");
+    track.setValue("model-shorter", model);
+
+    var funcHash = {
+      new: func (track, pathNode) {
+        me.track = track;
+        me.oldpath = pathNode.getValue();
+
+        me.listenerID1 = setlistener(track.getChild("valid"), func me.callme1(), nil, 1);
+        me.listenerID2 = setlistener(pathNode,                func me.callme2(), nil, 1);
+      },
+      callme1: func () {
+        if (!me.track.getChild("valid").getBoolValue()) {
+          me.del();
+        }
+      },
+      callme2: func () {
+        if (me.track.getNode("sim/model/path") == nil or me.track.getNode("sim/model/path").getValue() != me.oldpath) {
+          me.del();
+        }
+      },
+      del: func () {
+        var child = me.track.removeChild("model-shorter", 0); #index 0 must be specified!
+        # Careful not to remove the nil tests. If both listener at triggered at
+        # the same time, both will be executed even after 'removelistener'.
+        if (me.listenerID1 != nil) {
+          removelistener(me.listenerID1);
+          me.listenerID1 = nil;
+        }
+        if (me.listenerID2 != nil) {
+          removelistener(me.listenerID2);
+          me.listenerID2 = nil;
+        }
+        radar_logic.radarLogic.typeHashes[me.track.getPath()] = nil;
+      },
+    };
+    funcHash.new(track, pathNode);
+    me.typeHashes[track.getPath()] = funcHash;
+
+    return model;
+  },
+
+  getUID: func(track) {
+    var UID = track.getValue("unique");
+    if (UID == nil) {
+      UID = rand();
+      track.setDoubleValue("unique", UID);
+    }
+    return UID;
+  },
+
   paint: func (node, painted) {
-    if (node == nil) {
-      return;
-    }
-    me.attr = node.getChild("painted");
-    if (me.attr == nil) {
-      me.attr = node.addChild("painted");
-    }
-    me.attr.setBoolValue(painted);
-    #if(painted == TRUE) { 
-      #print("painted "~attr.getPath()~" "~painted);
-    #}
+    if (node == nil) return;
+    node.getChild("painted", 0, 1).setBoolValue(painted);
   },
 
-  remove_suffix: func(s, x) {
-      me.len = size(x);
-      if (substr(s, -me.len) == x)
-          return substr(s, 0, size(s) - me.len);
-      return s;
+  # Tests if the track can be seen by the radar, except for the line of sight
+  # check (which will have been done earlier).
+  isRadarVisible: func (track, trackInfo, trackPos, distance) {
+    if(track.getName() == "rb-99") return TRUE; # datalink
+    if(distance > radarRange) return FALSE;
+    if(!me.isInRadarAngles(trackPos)) return FALSE;
+    # An air radar can only pick up targets through doppler effect.
+    # Currently, ground radars are magic.
+    if(!groundRadar and !me.doppler(trackPos, track)) return FALSE;
+    # Finally RCS check
+    return rcs.inRadarRange(trackInfo, 40, 3.2);
   },
 
-# trackInfo
-#
-# 0 - x position
-# 1 - y position
-# 2 - direct distance in meter
-# 3 - distance in radar screen plane
-# 4 - horizontal angle from aircraft in rad
-# 5 - identifier
-# 6 - node
-# 7 - not targetable
+  # Checks that the track is within the radar angle limits
+  isInRadarAngles: func (trackPos) {
+    var alt = trackPos.alt();
 
-  trackItemCalc: func (track, range, carrier, mp, type) {
-    me.pos = track.getNode("position");
-    me.x = me.pos.getNode("global-x").getValue();
-    me.y = me.pos.getNode("global-y").getValue();
-    me.z = me.pos.getNode("global-z").getValue();
-    if(me.x == nil or me.y == nil or me.z == nil) {
-      return nil;
-    }
-    me.aircraftPos = geo.Coord.new().set_xyz(me.x, me.y, me.z);
-    me.item = me.trackCalc(me.aircraftPos, range, carrier, mp, type, track);
-    
-    return me.item;
+    # ground angle
+    var yg_rad = vector.Math.getPitch(self, trackPos) * D2R - myPitch;
+    var xg_rad = (self.course_to(trackPos) - myHeading) * D2R;
+    yg_rad = math.periodic(-math.pi, math.pi, yg_rad);
+    xg_rad = math.periodic(-math.pi, math.pi, xg_rad);
+
+    # aircraft angle
+    var ya_rad = xg_rad * math.sin(myRoll) + yg_rad * math.cos(myRoll);
+    var xa_rad = xg_rad * math.cos(myRoll) - yg_rad * math.sin(myRoll);
+    ya_rad = math.periodic(-math.pi, math.pi, ya_rad);
+    xa_rad = math.periodic(-math.pi, math.pi, xa_rad);
+
+    # Is within the radar cone AJ37 manual: 61.5 deg sideways.
+    return math.abs(ya_rad) <= 61.5*D2R and math.abs(xa_rad) <= 61.5*D2R;
   },
 
-  trackMissileCalc: func (track, range, carrier, mp, type) {
-    me.pos = track.getNode("position");
-    me.alt = me.pos.getNode("altitude-ft").getValue();
-    me.lat = me.pos.getNode("latitude-deg").getValue();
-    me.lon = me.pos.getNode("longitude-deg").getValue();
-    if(me.alt == nil or me.lat == nil or me.lon == nil) {
-      return nil;
-    }
-    me.aircraftPos = geo.Coord.new().set_latlon(me.lat, me.lon, me.alt*feet2meter);
-    return me.trackCalc(me.aircraftPos, range, carrier, mp, type, track);
+  # Tests if the track either has its transponder active, or has its radar active
+  # and pointed roughly towards us.
+  isRWRActive: func (trackPos, node) {
+    var squawk = node.getNode("instrumentation/transponder/transmitted-id");
+    if (squawk != nil and squawk.getValue() != -9999) return TRUE;
+
+    # Transponder off, test radar
+    var radar = node.getNode("sim/multiplay/generic/int[2]");
+    if (radar != nil and radar.getValue()) return FALSE;
+
+    # Radar is active, test if it is pointed at us
+    var heading = node.getNode("orientation/true-heading-deg").getValue();
+    var bearing = trackPos.course_to(self);
+    return math.abs(geo.normdeg180(heading - bearing)) <= 60;
   },
 
-  trackCalc: func (aircraftPos, range, carrier, mp, type, node) {
-    me.distance = nil;
-    me.distanceDirect = nil;
-    
-    call(func {me.distance = self.distance_to(aircraftPos); me.distanceDirect = self.direct_distance_to(aircraftPos);}, nil, var err = []);
+  # Try to guess the type of contact. This is not very reliable.
+  guessType: func (track, trackPos, model) {
+    # To help with classification, some ship models are hard-coded.
+    if(contains(knownShips, model)) return MARINE;
 
-    if ((size(err))or(me.distance==nil)) {
-      # Oops, have errors. Bogus position data (and distance==nil).
-      #print("Received invalid position data: dist "~distance);
-      #target_circle[track_index+maxTargetsMP].hide();
-      #print(i~" invalid pos.");
-      return nil;
+    # Assume that anything fast is an air target - we don't have many racing cars.
+    if(track.getValue("velocities/true-airspeed-kt") > 50) return AIR;
+
+    var ground = geodinfo(trackPos.lat(), trackPos.lon());
+    if(ground != nil) {
+        # Ground info below the target, allows a reasonably precise classification.
+        var AGL = trackPos.alt() - ground[0];
+        if(AGL > 10) return AIR;
+        elsif(!ground[1].solid) return MARINE; # On water
+        else return SURFACE;
+    } else {
+        if(trackPos.alt() < 3) return MARINE;
+        else return SURFACE;
     }
-
-    if (mp == TRUE or getprop("ja37/supported/picking") == TRUE) {
-      # is multiplayer or 2017.2.1+
-      if (me.isNotBehindTerrain(aircraftPos) == FALSE) {
-        #hidden behind terrain
-        return nil;
-      }
-    }
-
-    if (me.distance < 120000 and mp == TRUE and node.getNode("callsign") != nil and getprop("ja37/systems/variant") == 0 and TI.ti.ECMon == TRUE) {
-        # if within 120 Km and a multiplayer, we check if its radar beams are detected.
-        var callsign = node.getNode("callsign").getValue();
-        #print("callsign "~callsign);
-        if (!containsVector(me.friends, callsign)) {
-            # its not a friend, so lets do the check
-            if (node.getNode("orientation/true-heading-deg") != nil) {
-                var bearing = self.course_to(aircraftPos);
-                var trAct = node.getNode("instrumentation/transponder/transmitted-id");
-                if (trAct != nil and trAct.getValue() != -9999) {#hmm kinda of a hack
-                  # transponder on
-                  var clock = getClock(bearing-myHeading);
-                  rwr[clock-1] = TRUE;
-                } else {
-                  var heading = node.getNode("orientation/true-heading-deg").getValue();
-                  
-                  var inv_bearing =  bearing+180;
-                  var deviation = inv_bearing - heading;
-                  #print("dev "~deviation);
-                  var rdrAct = node.getNode("sim/multiplay/generic/int[2]");
-                  if (((rdrAct != nil and rdrAct.getValue()!=1) or rdrAct == nil) and math.abs(geo.normdeg180(deviation)) < 60) {
-                      # we detect its radar is pointed at us and active
-                      var clock = getClock(bearing-myHeading);
-                      rwr[clock-1] = TRUE;
-                  }
-                }
-            }
-        }
-    }
-
-    if (me.distanceDirect < range or node.getName() == "rb-99") {#is max radar range of ja37
-      # Node with valid position data (and "distance!=nil").
-      #distance = distance*kts2kmh*1000;
-      me.aircraftAlt = aircraftPos.alt(); #altitude in meters
-
-      #aircraftAlt = aircraftPos.x();
-      #myAlt = self.x();
-      #distance = math.sqrt(pow2(aircraftPos.z() - self.z()) + pow2(aircraftPos.y() - self.y()));
-
-      #ground angle
-      me.yg_rad = vector.Math.getPitch(self, aircraftPos)*D2R-myPitch;#math.atan2(aircraftAlt-myAlt, distance) - myPitch; 
-      me.xg_rad = (self.course_to(aircraftPos) - myHeading) * D2R;
-
-      while (me.xg_rad > math.pi) {
-        me.xg_rad = me.xg_rad - 2*math.pi;
-      }
-      while (me.xg_rad < -math.pi) {
-        me.xg_rad = me.xg_rad + 2*math.pi;
-      }
-      while (me.yg_rad > math.pi) {
-        me.yg_rad = me.yg_rad - 2*math.pi;
-      }
-      while (me.yg_rad < -math.pi) {
-        me.yg_rad = me.yg_rad + 2*math.pi;
-      }
-
-      #aircraft angle
-      me.ya_rad = me.xg_rad * math.sin(myRoll) + me.yg_rad * math.cos(myRoll);
-      me.xa_rad = me.xg_rad * math.cos(myRoll) - me.yg_rad * math.sin(myRoll);
-
-      while (me.xa_rad < -math.pi) {
-        me.xa_rad = me.xa_rad + 2*math.pi;
-      }
-      while (me.xa_rad > math.pi) {
-        me.xa_rad = me.xa_rad - 2*math.pi;
-      }
-      while (me.ya_rad > math.pi) {
-        me.ya_rad = me.ya_rad - 2*math.pi;
-      }
-      while (me.ya_rad < -math.pi) {
-        me.ya_rad = me.ya_rad + 2*math.pi;
-      }
-
-      if(node.getName() == "rb-99" or (me.ya_rad > -61.5 * D2R and me.ya_rad < 61.5 * D2R and me.xa_rad > -61.5 * D2R and me.xa_rad < 61.5 * D2R)) {
-        #is within the radar cone
-        # AJ37 manual: 61.5 deg sideways.
-
-        
-        if (mp == TRUE) {
-          me.shrtr = node.getChild("model-shorter")==nil?"nil":node.getChild("model-shorter").getValue();
-          if (me.doppler(aircraftPos, node) == TRUE) {
-            # doppler picks it up, must be an aircraft
-            type = AIR;
-          } elsif (me.aircraftAlt > 1 and !contains(knownShips, me.shrtr)) {
-            # doppler does not see it, and is not on sea, must be ground target
-            type = SURFACE;
-          } else {
-            type = MARINE;
-          }
-        }
-
-        me.contact = Contact.new(node, type);
-
-        return me.contact;
-        
-      }
-    }
-    return nil;
   },
 
 #

--- a/Aircraft/JA37/Nasal/radar/radar-logic.nas
+++ b/Aircraft/JA37/Nasal/radar/radar-logic.nas
@@ -109,22 +109,22 @@ var knownShips = {
 };
 
 var input = {
-        alt_ft:           "instrumentation/altimeter/indicated-altitude-ft",
-        alt_true_ft:      "position/altitude-ft",
-        radar_serv:       "instrumentation/radar/serviceable",
-        radar_range:      "instrumentation/radar/range",
-        hdgReal:          "/orientation/heading-deg",
-        pitch:            "/orientation/pitch-deg",
-        roll:             "/orientation/roll-deg",
-        tracks_enabled:   "ja37/hud/tracks-enabled",
-        callsign:         "/ja37/hud/callsign",
-        ai_models:        "/ai/models",
-        lookThrough:      "ja37/radar/look-through-terrain",
-        dopplerSpeed:     "ja37/radar/min-doppler-speed-kt",
+    alt_ft:           "instrumentation/altimeter/indicated-altitude-ft",
+    alt_true_ft:      "position/altitude-ft",
+    radar_serv:       "instrumentation/radar/serviceable",
+    radar_range:      "instrumentation/radar/range",
+    hdgReal:          "/orientation/heading-deg",
+    pitch:            "/orientation/pitch-deg",
+    roll:             "/orientation/roll-deg",
+    tracks_enabled:   "ja37/hud/tracks-enabled",
+    callsign:         "/ja37/hud/callsign",
+    ai_models:        "/ai/models",
+    lookThrough:      "ja37/radar/look-through-terrain",
+    dopplerSpeed:     "ja37/radar/min-doppler-speed-kt",
 };
 
-var RadarLogic = {
 
+var RadarLogic = {
     new: func() {
         var radarLogic     = { parents : [RadarLogic]};
         radarLogic.typeHashes = {};
@@ -138,7 +138,6 @@ var RadarLogic = {
     },
 
     findRadarTracks: func () {
-      me.friends = [getprop("ja37/faf/friend-1"),getprop("ja37/faf/friend-2"),getprop("ja37/faf/friend-3"),getprop("ja37/faf/friend-4"),getprop("ja37/faf/friend-5"),getprop("ja37/faf/friend-6")];
       rwr = [FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE];
       self      =  geo.aircraft_position();
       myPitch   =  input.pitch.getValue()*D2R;

--- a/Aircraft/JA37/Nasal/radar/rcs.nas
+++ b/Aircraft/JA37/Nasal/radar/rcs.nas
@@ -17,60 +17,107 @@ var test = func (echoHeading, echoPitch, echoRoll, bearing, frontRCS) {
 };
 
 var rcs_database = {
-    "default":                  200,    #default value if target's model isn't listed
+    "default":                  150,    #default value if target's model isn't listed
     "f-14b":                    12,     #guess
     "F-14D":                    12,     #guess
-    "f-14b-bs":                 0.001,   # low so it dont show up on radar
+    "f-14b-bs":                 0.0001, #low so it doesn't show up on radar
     "F-15C":                    10,     #low end of sources
     "F-15D":                    11,     #low end of sources
     "F-16":                     2,      #guess
-    "F-16":                     2,      #guess
-    "YF-16":                    2,      #guess
+    "YF-16":                    5,      #higher because earlier blocks had larger RCS
     "F-16CJ":                   2,      #guess
     "f16":                      2,      #guess
     "MiG-29":                   6,      #guess
-    "SU-27":                    10,      #guess
-    "f15-bs":                   0.001,   # low so it dont show up on radar
+    "SU-27":                    15,     #some data shows 22
+    "daVinci_SU-34":            15,     #same as Su-27 for now
+    "Su-34":                    15,     #same as Su-27 for now
+    "SU-37":                    15,
+    "J-11A":                    15,
+    "T-50":                     0.3,    #guess
+    "f15-bs":                   0.0001, #low so it doesn't show up on radar
     "JA37-Viggen":              3,      #guess
     "AJ37-Viggen":              3,      #guess
     "AJS37-Viggen":             3,      #guess
     "JA37Di-Viggen":            3,      #guess
     "m2000-5":                  1,
     "m2000-5B":                 1,
-    "m2000-5B-backseat":        0.001,
-    "707":                      100,    #guess
-    "707-TT":                   100,    #guess
-    "EC-137D":                  110,    #guess
+    "m2000-5B-backseat":        0.0001,
+    "707":                      90,     #guess
+    "707-TT":                   90,     #guess
+    "EC-137D":                  100,    #guess
+    "onox-tanker":              90,     #guess
     "B-1B":                     10,
+    "b2-spirit":                0.001,  #actual: 0.0001
+    "B-2A":                     0.001,  #actual: 0.0001
+    "F-117":                    0.003,
     "Blackbird-SR71A":          0.25,
     "Blackbird-SR71B":          0.30,
     "Blackbird-SR71A-BigTail":  0.30,
-    "ch53e":                    20,     #guess
+    "u-2s":                     0.01,
+    "U-2S-model":               0.01,
+    "ch53e":                    35,     #guess
+    "Mil-Mi-8":                 30,     #guess
+    "CH47":                     30,     #guess
+    "mi24":                     35,     #guess
     "MiG-21bis":                3.5,
-    "MQ-9":                     1,      #guess
-    "KC-137R":                  100,    #guess
-    "KC-137R-RT":               100,    #guess
-    "A-10":                     23.5, 
+    "MiG-21MF-75":              3.5,
+    "MiG-21Bison":              3.5,
+    "MQ-9":                     0.5,    #guess
+    "KC-137R":                  90,     #guess
+    "KC-137R-RT":               90,     #guess
+    "A-10":                     23.5,
+    "A-10-model":               23.5,
+    "A-10-modelB":              23.5, 
     "KC-10A":                   100,    #guess
+    "KC-10A-GE":                100,    #guess
+    "KC-30A":                   80,     #guess
+    "Voyager-KC":               80,     #guess
     "Typhoon":                  0.5,
-    "C-137R":                   100,    #guess
-    "RC-137R":                  100,    #guess
-    "EC-137R":                  110,    #guess
-    "c130":                     100,    #guess
-    "SH-60J":                   30,     #guess
-    "UH-60J":                   30,     #guess
-    "uh1":                      30,     #guess
-    "212-TwinHuey":             25,     #guess
-    "412-Griffin":              25,     #guess
+    "EF2000":                   0.5,
+    "brsq":                     2.5,
+    "C-137R":                   90,     #guess
+    "RC-137R":                  95,     #guess
+    "EC-137R":                  100,    #guess
+    "E-8R":                     95,     #guess
+    "c130":                     75,     #guess
+    "SH-60J":                   15,     #guess
+    "UH-60J":                   15,     #guess
+    "uh60_Blackhawk":           15,     #guess
+    "tigre":                    8,      #guess
+    "uh1":                      25,     #guess
+    "212-TwinHuey":             20,     #guess
+    "412-Griffin":              20,     #guess
     "QF-4E":                    1,      #actual: 6
     "depot":                    170,    #estimated with blender
+    "struct":                   170,    #estimated with blender
+    "rig":                      500,    #guess
+    "point":                    120,    #guess
     "buk-m2":                   7,      #estimated with blender
-    "s-300":                    17,      
+    "s-300":                    17,
     "truck":                    1.5,    #estimated with blender
     "missile_frigate":          450,    #estimated with blender
     "frigate":                  450,    #estimated with blender
+    "USS-NORMANDY":             450,    #estimated with blender
+    "USS-LakeChamplain":        450,    #estimated with blender
+    "USS-OliverPerry":          450,    #estimated with blender
+    "USS-SanAntonio":           450,    #estimated with blender
     "tower":                    60,     #estimated with blender
     "gci":                      50,     #guess
+    "FA-18C_Hornet":            3.5,
+    "FA-18D_Hornet":            3.5,
+    "F-22-Raptor":              0.001,  #actual: 0.0001
+    "F-35A":                    0.0005,
+    "F-35B":                    0.0005,
+    "F-35C":                    0.0005,
+    "Jaguar-GR1":               6,      #guess
+    "Jaguar-GR3":               6,      #guess
+    "f-20A":                    2.5,    #low end of sources
+    "f-20C":                    2.5,
+    "f-20prototype":            2.5,
+    "f-20bmw":                  2.5,
+    "f-20-dutchdemo":           2.5,
+    "MiG-15bis":                12,     #guess
+    "G91-R1B":                  7,      #guess
 };
 
 var prevVisible = {};

--- a/Aircraft/JA37/Nasal/radar/rcs.nas
+++ b/Aircraft/JA37/Nasal/radar/rcs.nas
@@ -130,10 +130,8 @@ var inRadarRange = func (contact, myRadarDistance_nm, myRadarStrength_rcs) {
     var callsign = contact.get_Callsign();
     var time = timeNode.getValue();
     if (callsign != nil and contains(validTime, callsign) and time < validTime[callsign]) {
-        print("cached result for "~callsign);
         return wasInRadarRange(contact, myRadarDistance_nm, myRadarStrength_rcs);
     } else {
-        print("new query for"~callsign);
         return isInRadarRange(contact, myRadarDistance_nm, myRadarStrength_rcs);
     }
 }

--- a/Aircraft/JA37/Nasal/radar/rcs.nas
+++ b/Aircraft/JA37/Nasal/radar/rcs.nas
@@ -74,9 +74,21 @@ var rcs_database = {
 };
 
 var prevVisible = {};
+var validTime = {};
+
+var timeNode = props.globals.getNode("sim/time/elapsed-sec");
+
 
 var inRadarRange = func (contact, myRadarDistance_nm, myRadarStrength_rcs) {
-    return rand() < 0.05?rcs.isInRadarRange(contact, myRadarDistance_nm, myRadarStrength_rcs) == 1:rcs.wasInRadarRange(contact, myRadarDistance_nm, myRadarStrength_rcs);
+    var callsign = contact.get_Callsign();
+    var time = timeNode.getValue();
+    if (callsign != nil and contains(validTime, callsign) and time < validTime[callsign]) {
+        print("cached result for "~callsign);
+        return wasInRadarRange(contact, myRadarDistance_nm, myRadarStrength_rcs);
+    } else {
+        print("new query for"~callsign);
+        return isInRadarRange(contact, myRadarDistance_nm, myRadarStrength_rcs);
+    }
 }
 
 var wasInRadarRange = func (contact, myRadarDistance_nm, myRadarStrength_rcs) {
@@ -99,7 +111,9 @@ var isInRadarRange = func (contact, myRadarDistance_nm, myRadarStrength_rcs) {
             # open radar for one will make this happen.
             return value;
         }
-        prevVisible[contact.get_Callsign()] = value;
+        var callsign = contact.get_Callsign();
+        prevVisible[callsign] = value;
+        validTime[callsign] = timeNode.getValue() + 3+2*rand();
         return value;
     }
     return 0;

--- a/Aircraft/JA37/Nasal/radar/rwr.nas
+++ b/Aircraft/JA37/Nasal/radar/rwr.nas
@@ -1,0 +1,115 @@
+var TRUE = 1;
+var FALSE = 0;
+
+
+### RWR logic: gather incoming radar signals
+
+
+# Number of distinct sectors for the RWR
+var sectors_n = 12;
+var sector_width = 360/sectors_n;
+# Types of RWR signals (give different warning sounds/lights)
+# Numbers represent priority
+var RWR_SQUAWK = 1; # Fairly confident this is not realistic
+var RWR_SCAN = 2;
+var RWR_LOCK = 3;
+var RWR_LAUNCH = 4;
+var RWR_SIGNAL_MIN = RWR_SQUAWK;
+var RWR_SIGNAL_MAX = RWR_LAUNCH;
+
+
+var bearing_to_sector = func(bearing) {
+    return int(geo.normdeg(bearing + (sector_width/2)) / sector_width);
+}
+
+
+var RWRSignal = {
+    signal_persist_time: 3, # Time for which a signal is displayed after disappearing, in sec
+
+    new: func(UID, type, bearing) {
+        var m = { parents: [RWRSignal] };
+        m.UID = UID;
+        m.delete_timer = maketimer(m.signal_persist_time, m, m.del);
+        m.delete_timer.singleShot = TRUE;
+        m.delete_timer.simulatedTime = TRUE;
+        m.delete_timer.start();
+        m.registered = FALSE;
+        m.bearing = bearing;
+        m.type = type;
+        m.register();
+        return m;
+    },
+    # The 'sectors_table' counts the number of signals in each sector.
+    # Each RWRSignal increments/decrements appropriately.
+    # The 'registered' flag indicates whether or not the present object
+    # has been counted in the table.
+    register: func() {
+        if (me.registered) return;
+        me.registered = TRUE;
+        sectors_table[me.type][bearing_to_sector(me.bearing)] += 1;
+    },
+    unregister: func() {
+        if (!me.registered) return;
+        me.registered = FALSE;
+        sectors_table[me.type][bearing_to_sector(me.bearing)] -= 1;
+    },
+    refresh: func(type, bearing) {
+        if(bearing != me.bearing or type != me.type) {
+            # Unregister from previous sector
+            me.unregister();
+            me.bearing = bearing;
+            me.type = type;
+            # Register in the new one
+            me.register();
+        }
+        me.delete_timer.restart(me.signal_persist_time);
+    },
+    del: func() {
+        me.delete_timer.stop();
+        me.unregister();
+        if(me.UID != nil) delete(signals_list, me.UID);
+    },
+};
+
+# List of RWR signals indexed by their UID.
+# Does not contain signals without UID
+var signals_list = {};
+
+# Register a RWR signal
+#
+# 'bearing' is the relative bearing in degrees
+# 'type' is the type of radar signal
+# If a previous signal was given with the same UID, then this signal is
+# updated instead of creating a new one.
+var signal = func(UID, type, bearing) {
+    if(contains(signals_list, UID)) {
+        var s = signals_list[UID];
+        s.refresh(type, bearing);
+        return s;
+    } else {
+        var s = RWRSignal.new(UID, type, bearing);
+        signals_list[UID] = s;
+        return s;
+    }
+}
+
+
+# For each sector and signal type, indicates the number of signals coming from this sector
+var sectors_table = [];
+# Initialization
+setsize(sectors_table, RWR_SIGNAL_MAX+1);
+for(var i=RWR_SIGNAL_MIN; i<=RWR_SIGNAL_MAX; i+=1) {
+    sectors_table[i] = [];
+    setsize(sectors_table[i], sectors_n);
+    for(var j=0; j<sectors_n; j+=1) {
+        sectors_table[i][j] = FALSE;
+    }
+}
+
+# Get the highest priority signal type in a given sector.
+var get_highest_signal = func(sector) {
+    for(var type=RWR_SIGNAL_MAX; type>=RWR_SIGNAL_MIN; type-=1) {
+        if(sectors_table[type][sector]) return type;
+    }
+    return 0;
+}

--- a/Aircraft/JA37/Nasal/radar/rwr.nas
+++ b/Aircraft/JA37/Nasal/radar/rwr.nas
@@ -13,7 +13,8 @@ var sector_width = 360/sectors_n;
 var RWR_SQUAWK = 1; # Fairly confident this is not realistic
 var RWR_SCAN = 2;
 var RWR_LOCK = 3;
-var RWR_LAUNCH = 4;
+var RWR_APPROACH = 4;   # Not used yet
+var RWR_LAUNCH = 5;
 var RWR_SIGNAL_MIN = RWR_SQUAWK;
 var RWR_SIGNAL_MAX = RWR_LAUNCH;
 

--- a/Aircraft/JA37/Viggen-set-base.xml
+++ b/Aircraft/JA37/Viggen-set-base.xml
@@ -80,18 +80,18 @@
             <path>ai/submodels/submodel[2]/random</path>
             <path>ai/submodels/submodel[3]/random</path>
             <path>ja37/displays/live-map</path>
-            <path>ja37/faf/friend-1</path>
-            <path>ja37/faf/friend-2</path>
-            <path>ja37/faf/friend-3</path>
-            <path>ja37/faf/friend-4</path>
-            <path>ja37/faf/friend-5</path>
-            <path>ja37/faf/friend-6</path>
-            <path>ja37/faf/foe-1</path>
-            <path>ja37/faf/foe-2</path>
-            <path>ja37/faf/foe-3</path>
-            <path>ja37/faf/foe-4</path>
-            <path>ja37/faf/foe-5</path>
-            <path>ja37/faf/foe-6</path>
+            <path>ja37/faf/friends/friend[0]</path>
+            <path>ja37/faf/friends/friend[1]</path>
+            <path>ja37/faf/friends/friend[2]</path>
+            <path>ja37/faf/friends/friend[3]</path>
+            <path>ja37/faf/friends/friend[4]</path>
+            <path>ja37/faf/friends/friend[5]</path>
+            <path>ja37/faf/foes/foe[0]</path>
+            <path>ja37/faf/foes/foe[1]</path>
+            <path>ja37/faf/foes/foe[2]</path>
+            <path>ja37/faf/foes/foe[3]</path>
+            <path>ja37/faf/foes/foe[4]</path>
+            <path>ja37/faf/foes/foe[5]</path>
             <!--<path>sim/model/livery/file</path>-->
         </aircraft-data>
 
@@ -758,18 +758,22 @@
             </fr31>
         </radio>
         <faf>
-            <friend-1 type="string"></friend-1>
-            <friend-2 type="string"></friend-2>
-            <friend-3 type="string"></friend-3>
-            <friend-4 type="string"></friend-4>
-            <friend-5 type="string"></friend-5>
-            <friend-6 type="string"></friend-6>
-            <foe-1 type="string"></foe-1>
-            <foe-2 type="string"></foe-2>
-            <foe-3 type="string"></foe-3>
-            <foe-4 type="string"></foe-4>
-            <foe-5 type="string"></foe-5>
-            <foe-6 type="string"></foe-6>
+            <friends>
+                <friend n="0" type="string"></friend>
+                <friend n="1" type="string"></friend>
+                <friend n="2" type="string"></friend>
+                <friend n="3" type="string"></friend>
+                <friend n="4" type="string"></friend>
+                <friend n="5" type="string"></friend>
+            </friends>
+            <foes>
+                <foe n="0" type="string"></foe>
+                <foe n="1" type="string"></foe>
+                <foe n="2" type="string"></foe>
+                <foe n="3" type="string"></foe>
+                <foe n="4" type="string"></foe>
+                <foe n="5" type="string"></foe>
+            </foes>
         </faf>
         <navigation>
             <inout type="bool">true</inout>
@@ -1580,6 +1584,9 @@
         <rcs>
             <file>Aircraft/JA37/Nasal/radar/rcs.nas</file>
         </rcs>
+        <faf>
+            <file>Aircraft/JA37/Nasal/radar/faf.nas</file>
+        </faf>
         <callsign>
             <file>Aircraft/JA37/Nasal/callsign.nas</file>
         </callsign>

--- a/Aircraft/JA37/Viggen-set-base.xml
+++ b/Aircraft/JA37/Viggen-set-base.xml
@@ -1584,6 +1584,9 @@
         <rcs>
             <file>Aircraft/JA37/Nasal/radar/rcs.nas</file>
         </rcs>
+        <rwr>
+            <file>Aircraft/JA37/Nasal/radar/rwr.nas</file>
+        </rwr>
         <faf>
             <file>Aircraft/JA37/Nasal/radar/faf.nas</file>
         </faf>

--- a/Aircraft/JA37/gui/dialogs/faf.xml
+++ b/Aircraft/JA37/gui/dialogs/faf.xml
@@ -43,7 +43,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Friend 1</label>
-	  	<property>ja37/faf/friend-1</property>
+	  	<property>ja37/faf/friends/friend[0]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -59,7 +59,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Friend 2</label>
-	  	<property>ja37/faf/friend-2</property>
+	  	<property>ja37/faf/friends/friend[1]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -75,7 +75,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Friend 3</label>
-	  	<property>ja37/faf/friend-3</property>
+	  	<property>ja37/faf/friends/friend[2]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -91,7 +91,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Friend 4</label>
-	  	<property>ja37/faf/friend-4</property>
+	  	<property>ja37/faf/friends/friend[3]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -107,7 +107,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Friend 5</label>
-	  	<property>ja37/faf/friend-5</property>
+	  	<property>ja37/faf/friends/friend[4]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -123,7 +123,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Friend 6</label>
-	  	<property>ja37/faf/friend-6</property>
+	  	<property>ja37/faf/friends/friend[5]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -139,7 +139,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Foe 1</label>
-	  	<property>ja37/faf/foe-1</property>
+	  	<property>ja37/faf/foes/foe[0]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -155,7 +155,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Foe 2</label>
-	  	<property>ja37/faf/foe-2</property>
+	  	<property>ja37/faf/foes/foe[1]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -171,7 +171,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Foe 3</label>
-	  	<property>ja37/faf/foe-3</property>
+	  	<property>ja37/faf/foes/foe[2]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -187,7 +187,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Foe 4</label>
-	  	<property>ja37/faf/foe-4</property>
+	  	<property>ja37/faf/foes/foe[3]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -203,7 +203,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Foe 5</label>
-	  	<property>ja37/faf/foe-5</property>
+	  	<property>ja37/faf/foes/foe[4]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -219,7 +219,7 @@
 	  	<width>250</width>
 	  	<height>25</height>
 	  	<label>Foe 6</label>
-	  	<property>ja37/faf/foe-6</property>
+	  	<property>ja37/faf/foes/foe[5]</property>
 	  	<live>true</live>
 	  	<halign>left</halign>
         <binding>
@@ -237,31 +237,17 @@
 		<legend>Switch</legend>
 		<binding>
 			<command>nasal</command>
-			<script>
-				var h1 = getprop("ja37/faf/foe-1");
-				var h2 = getprop("ja37/faf/foe-2");
-				var h3 = getprop("ja37/faf/foe-3");
-				var h4 = getprop("ja37/faf/foe-4");
-				var h5 = getprop("ja37/faf/foe-5");
-				var h6 = getprop("ja37/faf/foe-6");
-				var f1 = getprop("ja37/faf/friend-1");
-				var f2 = getprop("ja37/faf/friend-2");
-				var f3 = getprop("ja37/faf/friend-3");
-				var f4 = getprop("ja37/faf/friend-4");
-				var f5 = getprop("ja37/faf/friend-5");
-				var f6 = getprop("ja37/faf/friend-6");
-				setprop("ja37/faf/foe-1", f1);
-				setprop("ja37/faf/foe-2", f2);
-				setprop("ja37/faf/foe-3", f3);
-				setprop("ja37/faf/foe-4", f4);
-				setprop("ja37/faf/foe-5", f5);
-				setprop("ja37/faf/foe-6", f6);
-				setprop("ja37/faf/friend-1", h1);
-				setprop("ja37/faf/friend-2", h2);
-				setprop("ja37/faf/friend-3", h3);
-				setprop("ja37/faf/friend-4", h4);
-				setprop("ja37/faf/friend-5", h5);
-				setprop("ja37/faf/friend-6", h6);
+			<script><![CDATA[
+			    var friends = props.globals.getNode("ja37/faf/friends");
+				var foes = props.globals.getNode("ja37/faf/foes");
+			    for(var i=0; i<6; i+=1) {
+				    var friend = friends.getChild("friend", i);
+				    var foe = foes.getChild("foe", i);
+					var tmp = friend.getValue();
+					friend.setValue(foe.getValue());
+					foe.setValue(tmp);
+				}
+			  ]]>
 			</script>
 		</binding>
 	</button>


### PR DESCRIPTION
New features/bug fixed:
- Radar lock transmitted over MP for RWR. Shows as a red sector on JA RWR.
- `radar_logic.complete_list` was not complete. This caused the Rb05 to fail to hit targets >60° from aircraft axis. (The bug was there for a long time but it was essentially impossible to find a scenario where it would matter).
-  I think I fixed the bug in the RCS code which sometimes caused aircrafts to be displayed for a few seconds when entering radar range (but outside RCS range). It was caused by cached results never being invalidated -> added a deadline.
- Changes (improvements hopefully) to the contact type (air/ground/marine) classification. It no longer relies on the doppler test, which did not really make sense, and caused e.g. Rb74 to be unable to target an aircraft hidden from doppler radar (while Rb75 would suddently become capable of targeting that aircraft).
- Increased RWR max range to 200km. The previous 120km seems very low to me.
- Disable radar while on the ground (Nose gear compressed, this is accurate for the AJS, I assume the JA would not be very different).

I plan to do some work on the RWR (AJS badly needs it), but I don't want it to delay the bugfixes and the radar lock over MP, hence the new `rwr.nas` with some code which currently is far too complicated for what it does.
