### PR TITLE
HUD: Prototype hud shader for parallax

### DIFF
--- a/Aircraft/JA37/Models/Effects/hud.eff
+++ b/Aircraft/JA37/Models/Effects/hud.eff
@@ -23,6 +23,7 @@
     <sample-res><use>ja37/hud/sample-res</use></sample-res>
     <sample-far><use>ja37/hud/sample-far</use></sample-far>
     <hud-brightness><use>ja37/hud/brightness</use></hud-brightness>
+    <use-parallax>true</use-parallax>
     <hud-width-deg>28</hud-width-deg>
     <hud-height-deg>28</hud-height-deg>
     <optical-offset-pitch>-7.3</optical-offset-pitch>

--- a/Aircraft/JA37/Models/Effects/hud.eff
+++ b/Aircraft/JA37/Models/Effects/hud.eff
@@ -2,7 +2,7 @@
 
 <PropertyList>
   <name>Aircraft/JA37/Models/Effects/hud</name>
-  <inherits-from>Effects/hud</inherits-from>
+  <inherits-from>Aircraft/JA37/Models/Effects/hud/hud-parallax</inherits-from>
 
   <parameters>
     <splash-x>0</splash-x>

--- a/Aircraft/JA37/Models/Effects/hud.eff
+++ b/Aircraft/JA37/Models/Effects/hud.eff
@@ -23,5 +23,8 @@
     <sample-res><use>ja37/hud/sample-res</use></sample-res>
     <sample-far><use>ja37/hud/sample-far</use></sample-far>
     <hud-brightness><use>ja37/hud/brightness</use></hud-brightness>
+    <hud-width-deg>28</hud-width-deg>
+    <hud-height-deg>28</hud-height-deg>
+    <optical-offset-pitch>-7.3</optical-offset-pitch>
   </parameters>
 </PropertyList>

--- a/Aircraft/JA37/Models/Effects/hud/hud-parallax.eff
+++ b/Aircraft/JA37/Models/Effects/hud/hud-parallax.eff
@@ -75,6 +75,14 @@
 	<sample-res>0.0006</sample-res>
 	<sample-far>2.5</sample-far>
 	<hud-brightness>1.0</hud-brightness>
+	<!-- Angular width/height of the texture displayed by the hud -->
+	<hud-width-deg>25</hud-width-deg>
+	<hud-height-deg>25</hud-height-deg>
+	<!-- Rotation offset to the optical centerline direction,
+			i.e. the direction mapped to the center of the texture. -->
+	<optical-offset-yaw>0</optical-offset-yaw>
+	<optical-offset-pitch>0</optical-offset-pitch>
+	<optical-offset-roll>0</optical-offset-roll>
 </parameters>
 
 <technique n="4">
@@ -451,6 +459,31 @@
         <name>colorMode</name>
         <type>int</type>
         <value><use>material/color-mode-uniform</use></value>
+      </uniform>
+      <uniform>
+        <name>hud_width</name>
+        <type>float</type>
+        <value><use>hud-width-deg</use></value>
+      </uniform>
+      <uniform>
+        <name>hud_height</name>
+        <type>float</type>
+        <value><use>hud-height-deg</use></value>
+      </uniform>
+      <uniform>
+        <name>optical_yaw</name>
+        <type>float</type>
+        <value><use>optical-offset-yaw</use></value>
+      </uniform>
+      <uniform>
+        <name>optical_pitch</name>
+        <type>float</type>
+        <value><use>optical-offset-pitch</use></value>
+      </uniform>
+      <uniform>
+        <name>optical_roll</name>
+        <type>float</type>
+        <value><use>optical-offset-roll</use></value>
       </uniform>
     </pass>
   </technique>

--- a/Aircraft/JA37/Models/Effects/hud/hud-parallax.eff
+++ b/Aircraft/JA37/Models/Effects/hud/hud-parallax.eff
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PropertyList>
+  <name>Aircraft/JA37/Models/Effects/hud/hud-parallax</name>
+	<inherits-from>Effects/model-default</inherits-from>
+
+<parameters>
+	<texture n="1">
+		<image>Aircraft/Generic/Effects/window_frost.png</image>
+		<type>2d</type>
+		<filter>linear-mipmap-linear</filter>
+		<wrap-s>repeat</wrap-s>
+		<wrap-t>repeat</wrap-t>
+		<internal-format>normalized</internal-format>
+	</texture>
+	<!-- placeholder for the function texture used for fogging, wiper area,...-->
+	<texture n="2">
+		<image>Aircraft/Generic/Effects/hud-glass.rgb</image>
+		<type>2d</type>
+		<filter>linear-mipmap-linear</filter>
+		<wrap-s>repeat</wrap-s>
+		<wrap-t>repeat</wrap-t>
+		<internal-format>normalized</internal-format>
+	</texture>	
+	<!-- texture for reflections in the glass -->
+	<texture n="3">
+		<type>cubemap</type>
+		<images>
+			<positive-x>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_px.png</positive-x>
+			<negative-x>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_nx.png</negative-x>
+			<positive-y>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_py.png</positive-y>
+			<negative-y>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_ny.png</negative-y>
+			<positive-z>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_pz.png</positive-z>
+			<negative-z>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_nz.png</negative-z>
+		</images>
+		</texture>
+	<!-- placeholder lightmap texture for reflections in the glass -->
+	<texture n="4">
+		<type>cubemap</type>
+		<images>
+			<positive-x>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_px.png</positive-x>
+			<negative-x>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_nx.png</negative-x>
+			<positive-y>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_py.png</positive-y>
+			<negative-y>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_ny.png</negative-y>
+			<positive-z>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_pz.png</positive-z>
+			<negative-z>Aircraft/Generic/Effects/CubeMaps/fair-sky/fair-sky_nz.png</negative-z>
+		</images>
+		</texture>
+	<glass-tint type="vec4d" n="0"> 0.95 1.0 0.95 1.0</glass-tint>
+	<overlay-color type="vec3d" n="0"> 0.8 1.0 0.9</overlay-color>
+	<splash-x><use>/environment/aircraft-effects/splash-vector-x</use></splash-x>
+	<splash-y><use>/environment/aircraft-effects/splash-vector-y</use></splash-y>
+	<splash-z><use>/environment/aircraft-effects/splash-vector-z</use></splash-z>
+	<rnorm><use>/environment/rain-norm</use></rnorm>
+	<gsnorm><use>/environment/aircraft-effects/ground-splash-norm</use></gsnorm>
+	<frost-level><use>/environment/aircraft-effects/frost-level</use></frost-level>
+	<surface-mapping-scheme type="int">0</surface-mapping-scheme>
+	<fog-level><use>/environment/aircraft-effects/fog-level</use></fog-level>
+	<use-wipers><use>/environment/aircraft-effects/use-wipers</use></use-wipers>
+	<use-overlay>1</use-overlay>
+	<overlay-alpha type="float">0.35</overlay-alpha>
+	<overlay-glare type="float">0.4</overlay-glare>
+	<use-reflection type="int">0</use-reflection>
+	<reflection-strength type="float">1.0</reflection-strength>
+	<use-mask type="int">1</use-mask>
+	<use-reflection-lightmap type="int">0</use-reflection-lightmap>
+	<lightmap-multi type="int">0</lightmap-multi>
+	<lightmap-factor type="float" n="0">1.0</lightmap-factor>
+	<lightmap-color type="vec3d" n="0"> 1.0 1.0 1.0 </lightmap-color>
+	<lightmap-factor type="float" n="1">1.0</lightmap-factor>
+	<lightmap-color type="vec3d" n="1"> 1.0 1.0 1.0 </lightmap-color>
+	<lightmap-factor type="float" n="2">1.0</lightmap-factor>
+	<lightmap-color type="vec3d" n="2"> 1.0 1.0 1.0 </lightmap-color>
+	<lightmap-factor type="float" n="3">1.0</lightmap-factor>
+	<lightmap-color type="vec3d" n="3"> 1.0 1.0 1.0 </lightmap-color>
+	<sample-res>0.0006</sample-res>
+	<sample-far>2.5</sample-far>
+	<hud-brightness>1.0</hud-brightness>
+</parameters>
+
+<technique n="4">
+    <predicate>
+      <and>
+        <property>/sim/rendering/shaders/skydome</property>
+        <or>
+          <less-equal>
+            <value type="float">2.0</value>
+            <glversion/>
+          </less-equal>
+          <and>
+            <extension-supported>GL_ARB_shader_objects</extension-supported>
+            <extension-supported>GL_ARB_shading_language_100</extension-supported>
+            <extension-supported>GL_ARB_vertex_shader</extension-supported>
+            <extension-supported>GL_ARB_fragment_shader</extension-supported>
+          </and>
+        </or>
+      </and>
+    </predicate>
+    <pass>
+      <lighting>true</lighting>
+      <depth>
+	<write-mask type="bool">false</write-mask>
+      </depth>
+      <material>
+        <active><use>material/active</use></active>
+        <ambient><use>material/ambient</use></ambient>
+        <diffuse><use>material/diffuse</use></diffuse>
+        <specular><use>material/specular</use></specular>
+        <emissive><use>material/emissive</use></emissive>
+        <shininess><use>material/shininess</use></shininess>
+        <color-mode><use>material/color-mode</use></color-mode>
+      </material>
+      <blend>
+        <active><use>blend/active</use></active>
+        <source><use>blend/source</use></source>
+        <destination><use>blend/destination</use></destination>
+      </blend>
+      <shade-model><use>shade-model</use></shade-model>
+      <cull-face><use>cull-face</use></cull-face>
+      <rendering-hint><use>rendering-hint</use></rendering-hint>
+      <render-bin>
+        <bin-number>111</bin-number>
+        <bin-name>DepthSortedBin</bin-name>
+      </render-bin>
+      <texture-unit>
+        <!-- The texture unit is always active because the shaders expect
+             that. -->
+        <unit>0</unit>
+        <type><use>texture[0]/type</use></type>
+        <image><use>texture[0]/image</use></image>
+        <filter><use>texture[0]/filter</use></filter>
+        <wrap-s><use>texture[0]/wrap-s</use></wrap-s>
+        <wrap-t><use>texture[0]/wrap-t</use></wrap-t>
+        <internal-format> <use>texture[0]/internal-format</use> </internal-format>
+      </texture-unit>
+      <texture-unit>
+        <unit>1</unit>
+        <type><use>texture[1]/type</use></type>
+        <image><use>texture[1]/image</use></image>
+        <filter><use>texture[1]/filter</use></filter>
+        <wrap-s><use>texture[1]/wrap-s</use></wrap-s>
+        <wrap-t><use>texture[1]/wrap-t</use></wrap-t>
+        <internal-format><use>texture[1]/internal-format</use></internal-format>
+      </texture-unit>
+      <texture-unit>
+        <unit>2</unit>
+        <type><use>texture[2]/type</use></type>
+        <image><use>texture[2]/image</use></image>
+        <filter><use>texture[2]/filter</use></filter>
+        <wrap-s><use>texture[2]/wrap-s</use></wrap-s>
+        <wrap-t><use>texture[2]/wrap-t</use></wrap-t>
+        <internal-format><use>texture[2]/internal-format</use></internal-format>
+      </texture-unit>
+      <texture-unit>
+	<unit>3</unit>
+	<type><use>texture[3]/type</use></type>
+	<images><use>texture[3]/images</use></images>
+      </texture-unit>
+      <texture-unit>
+	<unit>4</unit>
+	<type><use>texture[4]/type</use></type>
+	<images><use>texture[4]/images</use></images>
+      </texture-unit>
+      <vertex-program-two-side>
+        <use>vertex-program-two-side</use>
+      </vertex-program-two-side>
+      <program>
+        <vertex-shader>Aircraft/JA37/Models/Effects/hud/hud-parallax.vert</vertex-shader>
+        <fragment-shader>Aircraft/JA37/Models/Effects/hud/hud-parallax.frag</fragment-shader>
+        <fragment-shader>Shaders/noise.frag</fragment-shader>
+        <fragment-shader>Shaders/filters-ALS.frag</fragment-shader>
+      </program>
+
+     <uniform>
+        <name>tint</name>
+        <type>float-vec4</type>
+        <value><use>glass-tint</use></value>
+     </uniform>
+     <uniform>
+        <name>overlay_color</name>
+        <type>float-vec3</type>
+        <value><use>overlay-color</use></value>
+     </uniform>
+     <uniform>
+	<name>lightmap_r_factor</name>
+	<type>float</type>
+	<value><use>lightmap-factor[0]</use></value>
+     </uniform>	   
+     <uniform>
+	<name>lightmap_r_color</name>
+	<type>float-vec3</type>
+	<value><use>lightmap-color[0]</use></value>
+     </uniform>
+    <uniform>
+	<name>lightmap_g_factor</name>
+	<type>float</type>
+	<value><use>lightmap-factor[1]</use></value>
+     </uniform>	   
+     <uniform>
+	<name>lightmap_g_color</name>
+	<type>float-vec3</type>
+	<value><use>lightmap-color[1]</use></value>
+     </uniform>
+    <uniform>
+	<name>lightmap_b_factor</name>
+	<type>float</type>
+	<value><use>lightmap-factor[2]</use></value>
+     </uniform>	   
+     <uniform>
+	<name>lightmap_b_color</name>
+	<type>float-vec3</type>
+	<value><use>lightmap-color[2]</use></value>
+     </uniform>
+    <uniform>
+	<name>lightmap_a_factor</name>
+	<type>float</type>
+	<value><use>lightmap-factor[3]</use></value>
+     </uniform>	   
+     <uniform>
+	<name>lightmap_a_color</name>
+	<type>float-vec3</type>
+	<value><use>lightmap-color[3]</use></value>
+     </uniform>
+     <uniform>
+        <name>splash_x</name>
+        <type>float</type>
+        <value><use>splash-x</use></value>
+     </uniform>
+     <uniform>
+        <name>splash_y</name>
+        <type>float</type>
+        <value><use>splash-y</use></value>
+     </uniform>
+     <uniform>
+        <name>splash_z</name>
+        <type>float</type>
+        <value><use>splash-z</use></value>
+      </uniform>
+      <uniform>
+        <name>rain_norm</name>
+        <type>float</type>
+        <value><use>rnorm</use></value>
+      </uniform>
+      <uniform>
+        <name>ground_splash_norm</name>
+        <type>float</type>
+        <value><use>gsnorm</use></value>
+      </uniform>
+      <uniform>
+        <name>frost_level</name>
+        <type>float</type>
+        <value><use>frost-level</use></value>
+      </uniform>
+      <uniform>
+        <name>fog_level</name>
+        <type>float</type>
+        <value><use>fog-level</use></value>
+      </uniform>
+      <uniform>
+        <name>sample_res</name>
+        <type>float</type>
+        <value><use>sample-res</use></value>
+      </uniform>
+      <uniform>
+        <name>sample_far</name>
+        <type>float</type>
+        <value><use>sample-far</use></value>
+      </uniform>
+     <uniform>
+        <name>hud_brightness</name>
+        <type>float</type>
+        <value><use>hud-brightness</use></value>
+      </uniform>
+      <uniform>
+        <name>scattering</name>
+        <type>float</type>
+        <value><use>scattering</use></value>
+      </uniform>
+      <uniform>
+	<name>terminator</name>
+	<type>float</type>
+	<value><use>terminator</use></value>
+      </uniform>
+      <uniform>
+        <name>ground_scattering</name>
+        <type>float</type>
+        <value><use>ground_scattering</use></value>
+      </uniform>
+      <uniform>
+	<name>terminator</name>
+	<type>float</type>
+	<value><use>terminator</use></value>
+      </uniform>
+      <uniform>
+        <name>overcast</name>
+        <type>float</type>
+        <value><use>overcast</use></value>
+      </uniform>
+       <uniform>
+        <name>hazeLayerAltitude</name>
+        <type>float</type>
+        <value><use>lthickness</use></value>
+      </uniform>
+     <uniform>
+        <name>eye_alt</name>
+        <type>float</type>
+        <value><use>eye_alt</use></value>
+      </uniform>
+      <uniform>
+        <name>cloud_self_shading</name>
+        <type>float</type>
+        <value><use>cloud_self_shading</use></value>
+      </uniform>
+      <uniform>
+        <name>moonlight</name>
+        <type>float</type>
+        <value><use>moonlight</use></value>
+      </uniform>
+      <uniform>
+        <name>air_pollution</name>
+        <type>float</type>
+        <value><use>air_pollution</use></value>
+      </uniform>
+      <uniform>
+        <name>reflection_strength</name>
+        <type>float</type>
+        <value><use>reflection-strength</use></value>
+      </uniform>
+      <uniform>
+        <name>overlay_alpha</name>
+        <type>float</type>
+        <value><use>overlay-alpha</use></value>
+      </uniform>
+      <uniform>
+        <name>overlay_glare</name>
+        <type>float</type>
+        <value><use>overlay-glare</use></value>
+      </uniform>
+	<!-- filtering -->
+      <uniform>
+        <name>gamma</name>
+        <type>float</type>
+        <value><use>gamma</use></value>
+      </uniform>
+      <uniform>
+        <name>brightness</name>
+        <type>float</type>
+        <value><use>brightness</use></value>
+      </uniform>
+      <uniform>
+        <name>use_filtering</name>
+        <type>bool</type>
+        <value><use>use_filtering</use></value>
+      </uniform>
+      <uniform>
+        <name>use_night_vision</name>
+        <type>bool</type>
+        <value><use>use_night_vision</use></value>
+      </uniform>
+      <uniform>
+        <name>use_IR_vision</name>
+        <type>bool</type>
+        <value><use>use_IR_vision</use></value>
+      </uniform>
+      <uniform>
+        <name>delta_T</name>
+        <type>float</type>
+        <value><use>delta_T</use></value>
+      </uniform>
+      <uniform>
+        <name>fact_grey</name>
+        <type>float</type>
+        <value><use>fact_grey</use></value>
+      </uniform>
+      <uniform>
+        <name>fact_black</name>
+        <type>float</type>
+        <value><use>fact_black</use></value>
+      </uniform>
+      <uniform>
+        <name>display_xsize</name>
+        <type>int</type>
+        <value><use>display_xsize</use></value>
+      </uniform>
+      <uniform>
+        <name>display_ysize</name>
+        <type>int</type>
+        <value><use>display_ysize</use></value>
+      </uniform>
+
+      <uniform>
+        <name>texture</name>
+        <type>sampler-2d</type>
+        <value type="int">0</value>
+      </uniform>
+      <uniform>
+        <name>frost_texture</name>
+        <type>sampler-2d</type>
+        <value type="int">1</value>
+      </uniform>
+      <uniform>
+        <name>func_texture</name>
+        <type>sampler-2d</type>
+        <value type="int">2</value>
+      </uniform>
+      <uniform>
+	<name>cube_texture</name>
+        <type>sampler-cube</type>
+	<value type="int">3</value>
+      </uniform>
+      <uniform>
+	<name>cube_light_texture</name>
+        <type>sampler-cube</type>
+	<value type="int">4</value>
+      </uniform>
+      <uniform>
+	<name>use_reflection</name>
+	<type>int</type>
+	<value><use>use-reflection</use></value>
+      </uniform>
+      <uniform>
+	<name>use_mask</name>
+	<type>int</type>
+	<value><use>use-mask</use></value>
+      </uniform>
+      <uniform>
+	<name>use_wipers</name>
+	<type>int</type>
+	<value><use>use-wipers</use></value>
+      </uniform>
+      <uniform>
+	<name>use_overlay</name>
+	<type>int</type>
+	<value><use>use-overlay</use></value>
+      </uniform>
+      <uniform>
+	<name>use_reflection_lightmap</name>
+	<type>int</type>
+	<value><use>use-reflection-lightmap</use></value>
+      </uniform>
+      <uniform>
+	<name>lightmap_multi</name>
+	<type>int</type>
+	<value><use>lightmap-multi</use></value>
+      </uniform>
+      <uniform>
+	<name>adaptive_mapping</name>
+	<type>int</type>
+	<value><use>surface-mapping-scheme</use></value>
+      </uniform>
+      <uniform>
+        <name>colorMode</name>
+        <type>int</type>
+        <value><use>material/color-mode-uniform</use></value>
+      </uniform>
+    </pass>
+  </technique>
+
+  <!-- fall back to a fixed pipeline technique equivalent to model-transparent otherwise -->
+  <!-- Rembrandt technique of model-default comes at 10, so we insert before that -->
+
+  <technique n="9">
+		<pass>
+			<lighting>true</lighting>
+			<depth>
+				<write-mask type="bool">false</write-mask>
+			</depth>
+			<material>
+				<active>
+					<use>material/active</use>
+				</active>
+				<ambient>
+					<use>material/ambient</use>
+				</ambient>
+				<diffuse>
+					<use>material/diffuse</use>
+				</diffuse>
+				<specular>
+					<use>material/specular</use>
+				</specular>
+				<emissive>
+					<use>material/emissive</use>
+				</emissive>
+				<shininess>
+					<use>material/shininess</use>
+				</shininess>
+				<color-mode>
+					<use>material/color-mode</use>
+				</color-mode>
+			</material>
+			<blend>
+				<active>
+					<use>blend/active</use>
+				</active>
+				<source>
+					<use>blend/source</use>
+				</source>
+				<destination>
+					<use>blend/destination</use>
+				</destination>
+			</blend>
+			<shade-model>
+				<use>shade-model</use>
+			</shade-model>
+			<cull-face>
+				<use>cull-face</use>
+			</cull-face>
+				<render-bin>
+					<bin-number>111</bin-number>
+					<bin-name>DepthSortedBin</bin-name>
+				</render-bin>
+			<texture-unit>
+				<unit>0</unit>
+				<active>
+					<use>texture[0]/active</use>
+				</active>
+                <type>
+                    <use>texture[0]/type</use>
+                </type>
+				<image>
+					<use>texture[0]/image</use>
+				</image>
+				<filter>
+					<use>texture[0]/filter</use>
+				</filter>
+				<wrap-s>
+					<use>texture[0]/wrap-s</use>
+				</wrap-s>
+				<wrap-t>
+					<use>texture[0]/wrap-t</use>
+				</wrap-t>
+      
+				<environment>
+					<mode>modulate</mode>
+				</environment>
+			</texture-unit>
+		</pass>
+	</technique>
+
+
+</PropertyList>

--- a/Aircraft/JA37/Models/Effects/hud/hud-parallax.eff
+++ b/Aircraft/JA37/Models/Effects/hud/hud-parallax.eff
@@ -75,11 +75,19 @@
 	<sample-res>0.0006</sample-res>
 	<sample-far>2.5</sample-far>
 	<hud-brightness>1.0</hud-brightness>
-	<!-- Angular width/height of the texture displayed by the hud -->
+	<!-- Parallax correction.
+		If enabled, the HUD texture is displayed straight in front of the view point,
+		and with a constant angular width. This simulates collimation.
+		In that case, the HUD object UV mapping is completely ignored. -->
+	<use-parallax type="bool">false</use-parallax>
+	<!-- Angular width/height of the HUD texture (when using parallax). -->
 	<hud-width-deg>25</hud-width-deg>
 	<hud-height-deg>25</hud-height-deg>
-	<!-- Rotation offset to the optical centerline direction,
-			i.e. the direction mapped to the center of the texture. -->
+	<!-- The optical axis is the direction from the viewpoint at which the texture
+		is centered when using parallax correction.
+		By default, it is the '-x' axis in the HUD object model space, which is forward
+		if no rotation offsets are applied to the HUD object.
+		Additional offsets to the optical axis can be given here. -->
 	<optical-offset-yaw>0</optical-offset-yaw>
 	<optical-offset-pitch>0</optical-offset-pitch>
 	<optical-offset-roll>0</optical-offset-roll>
@@ -459,6 +467,11 @@
         <name>colorMode</name>
         <type>int</type>
         <value><use>material/color-mode-uniform</use></value>
+      </uniform>
+      <uniform>
+        <name>use_parallax</name>
+        <type>bool</type>
+        <value><use>use-parallax</use></value>
       </uniform>
       <uniform>
         <name>hud_width</name>

--- a/Aircraft/JA37/Models/Effects/hud/hud-parallax.frag
+++ b/Aircraft/JA37/Models/Effects/hud/hud-parallax.frag
@@ -7,7 +7,7 @@ varying vec3 vertPos;
 varying vec3 normal;
 varying vec3 refl_vec;
 varying vec3 light_diffuse;
-varying vec3 relPos;
+varying vec3 optical_relpos;
 varying float splash_angle;
 varying float Mie;
 varying float ambient_fraction;
@@ -42,6 +42,9 @@ uniform float sample_res;
 uniform float sample_far;
 uniform float hud_brightness;
 
+uniform float hud_width;
+uniform float hud_height;
+
 uniform int use_reflection;
 uniform int use_reflection_lightmap;
 uniform int use_mask;
@@ -70,7 +73,11 @@ vec4 texel;
 vec4 frost_texel;
 vec4 func_texel;
 
-vec2 parallax_TexCoord = -relPos.yz / relPos.x * 3 + vec2(0.5, 0.5);
+vec2 relAngle = vec2(
+    atan(optical_relpos.y, -optical_relpos.x),
+    atan(optical_relpos.z, -optical_relpos.x)
+);
+vec2 parallax_TexCoord = (relAngle / vec2(radians(hud_width), radians(hud_height))) + 0.5;
 
 texel = texture2D(texture, parallax_TexCoord.st);
 

--- a/Aircraft/JA37/Models/Effects/hud/hud-parallax.frag
+++ b/Aircraft/JA37/Models/Effects/hud/hud-parallax.frag
@@ -42,6 +42,8 @@ uniform float sample_res;
 uniform float sample_far;
 uniform float hud_brightness;
 
+uniform bool use_parallax;
+
 uniform float hud_width;
 uniform float hud_height;
 
@@ -73,28 +75,34 @@ vec4 texel;
 vec4 frost_texel;
 vec4 func_texel;
 
-vec2 relAngle = vec2(
-    atan(optical_relpos.y, -optical_relpos.x),
-    atan(optical_relpos.z, -optical_relpos.x)
-);
-vec2 parallax_TexCoord = (relAngle / vec2(radians(hud_width), radians(hud_height))) + 0.5;
+vec2 TexCoord;
 
-texel = texture2D(texture, parallax_TexCoord.st);
+if (use_parallax) {
+	vec2 relAngle = vec2(
+		atan(optical_relpos.y, -optical_relpos.x),
+		atan(optical_relpos.z, -optical_relpos.x)
+	);
+	TexCoord = (relAngle / vec2(radians(hud_width), radians(hud_height))) + 0.5;
+} else {
+	TexCoord = gl_TexCoord[0].st;
+}
 
-texel+= texture2D(texture, vec2 (parallax_TexCoord.s + sample_res, parallax_TexCoord.t));
-texel+= texture2D(texture, vec2 (parallax_TexCoord.s - sample_res, parallax_TexCoord.t));
-texel+= texture2D(texture, vec2 (parallax_TexCoord.s, parallax_TexCoord.t + sample_res));
-texel+= texture2D(texture, vec2 (parallax_TexCoord.s, parallax_TexCoord.t - sample_res));
+texel = texture2D(texture, TexCoord.st);
 
-texel+= 0.75* texture2D(texture, vec2 (parallax_TexCoord.s + sample_far * sample_res, parallax_TexCoord.t+ sample_far * sample_res));
-texel+= 0.75* texture2D(texture, vec2 (parallax_TexCoord.s - sample_far * sample_res, parallax_TexCoord.t+ sample_far * sample_res));
-texel+= 0.75* texture2D(texture, vec2 (parallax_TexCoord.s + sample_far * sample_res, parallax_TexCoord.t- sample_far * sample_res));
-texel+= 0.75* texture2D(texture, vec2 (parallax_TexCoord.s - sample_far * sample_res, parallax_TexCoord.t- sample_far * sample_res));
+texel+= texture2D(texture, vec2 (TexCoord.s + sample_res, TexCoord.t));
+texel+= texture2D(texture, vec2 (TexCoord.s - sample_res, TexCoord.t));
+texel+= texture2D(texture, vec2 (TexCoord.s, TexCoord.t + sample_res));
+texel+= texture2D(texture, vec2 (TexCoord.s, TexCoord.t - sample_res));
 
-texel+= 0.5 * texture2D(texture, vec2 (parallax_TexCoord.s + 2.0 * sample_far * sample_res, parallax_TexCoord.t - sample_res));
-texel+= 0.5 * texture2D(texture, vec2 (parallax_TexCoord.s - 2.0 * sample_far * sample_res, parallax_TexCoord.t + sample_res));
-texel+= 0.5 * texture2D(texture, vec2 (parallax_TexCoord.s - sample_res, parallax_TexCoord.t + 2.0 * sample_far * sample_res));
-texel+= 0.5 * texture2D(texture, vec2 (parallax_TexCoord.s + sample_res, parallax_TexCoord.t - 2.0 * sample_far * sample_res));
+texel+= 0.75* texture2D(texture, vec2 (TexCoord.s + sample_far * sample_res, TexCoord.t+ sample_far * sample_res));
+texel+= 0.75* texture2D(texture, vec2 (TexCoord.s - sample_far * sample_res, TexCoord.t+ sample_far * sample_res));
+texel+= 0.75* texture2D(texture, vec2 (TexCoord.s + sample_far * sample_res, TexCoord.t- sample_far * sample_res));
+texel+= 0.75* texture2D(texture, vec2 (TexCoord.s - sample_far * sample_res, TexCoord.t- sample_far * sample_res));
+
+texel+= 0.5 * texture2D(texture, vec2 (TexCoord.s + 2.0 * sample_far * sample_res, TexCoord.t - sample_res));
+texel+= 0.5 * texture2D(texture, vec2 (TexCoord.s - 2.0 * sample_far * sample_res, TexCoord.t + sample_res));
+texel+= 0.5 * texture2D(texture, vec2 (TexCoord.s - sample_res, TexCoord.t + 2.0 * sample_far * sample_res));
+texel+= 0.5 * texture2D(texture, vec2 (TexCoord.s + sample_res, TexCoord.t - 2.0 * sample_far * sample_res));
 
 texel/=10.0;
 

--- a/Aircraft/JA37/Models/Effects/hud/hud-parallax.frag
+++ b/Aircraft/JA37/Models/Effects/hud/hud-parallax.frag
@@ -1,0 +1,291 @@
+// -*-C++-*-
+#version 120
+
+varying vec2 rawPos;
+varying vec2 nPos;
+varying vec3 vertPos;
+varying vec3 normal;
+varying vec3 refl_vec;
+varying vec3 light_diffuse;
+varying vec3 relPos;
+varying float splash_angle;
+varying float Mie;
+varying float ambient_fraction;
+
+uniform sampler2D texture;
+uniform sampler2D frost_texture;
+uniform sampler2D func_texture;
+uniform samplerCube cube_texture;
+uniform samplerCube cube_light_texture;
+
+uniform vec4 tint;
+uniform vec3 overlay_color;
+
+
+uniform float rain_norm;
+uniform float ground_splash_norm;
+uniform float frost_level;
+uniform float fog_level;
+uniform float reflection_strength;
+uniform float overlay_alpha;
+uniform float overlay_glare;
+uniform float splash_x;
+uniform float splash_y;
+uniform float splash_z;
+uniform float lightmap_r_factor;
+uniform float lightmap_g_factor;
+uniform float lightmap_b_factor;
+uniform float lightmap_a_factor;
+uniform float osg_SimulationTime;
+
+uniform float sample_res;
+uniform float sample_far;
+uniform float hud_brightness;
+
+uniform int use_reflection;
+uniform int use_reflection_lightmap;
+uniform int use_mask;
+uniform int use_wipers;
+uniform int use_overlay;
+uniform int adaptive_mapping;
+uniform int lightmap_multi;
+
+uniform vec3 lightmap_r_color;
+uniform vec3 lightmap_g_color;
+uniform vec3 lightmap_b_color;
+uniform vec3 lightmap_a_color;
+
+float DotNoise2D(in vec2 coord, in float wavelength, in float fractionalMaxDotSize, in float dot_density);
+float DropletNoise2D(in vec2 coord, in float wavelength, in float fractionalMaxDotSize, in float dot_density);
+float Noise2D(in vec2 coord, in float wavelength);
+vec3 filter_combined (in vec3 color) ;
+
+void main()
+{
+
+vec4 texel;
+
+
+
+vec4 frost_texel;
+vec4 func_texel;
+
+vec2 parallax_TexCoord = -relPos.yz / relPos.x * 3 + vec2(0.5, 0.5);
+
+texel = texture2D(texture, parallax_TexCoord.st);
+
+texel+= texture2D(texture, vec2 (parallax_TexCoord.s + sample_res, parallax_TexCoord.t));
+texel+= texture2D(texture, vec2 (parallax_TexCoord.s - sample_res, parallax_TexCoord.t));
+texel+= texture2D(texture, vec2 (parallax_TexCoord.s, parallax_TexCoord.t + sample_res));
+texel+= texture2D(texture, vec2 (parallax_TexCoord.s, parallax_TexCoord.t - sample_res));
+
+texel+= 0.75* texture2D(texture, vec2 (parallax_TexCoord.s + sample_far * sample_res, parallax_TexCoord.t+ sample_far * sample_res));
+texel+= 0.75* texture2D(texture, vec2 (parallax_TexCoord.s - sample_far * sample_res, parallax_TexCoord.t+ sample_far * sample_res));
+texel+= 0.75* texture2D(texture, vec2 (parallax_TexCoord.s + sample_far * sample_res, parallax_TexCoord.t- sample_far * sample_res));
+texel+= 0.75* texture2D(texture, vec2 (parallax_TexCoord.s - sample_far * sample_res, parallax_TexCoord.t- sample_far * sample_res));
+
+texel+= 0.5 * texture2D(texture, vec2 (parallax_TexCoord.s + 2.0 * sample_far * sample_res, parallax_TexCoord.t - sample_res));
+texel+= 0.5 * texture2D(texture, vec2 (parallax_TexCoord.s - 2.0 * sample_far * sample_res, parallax_TexCoord.t + sample_res));
+texel+= 0.5 * texture2D(texture, vec2 (parallax_TexCoord.s - sample_res, parallax_TexCoord.t + 2.0 * sample_far * sample_res));
+texel+= 0.5 * texture2D(texture, vec2 (parallax_TexCoord.s + sample_res, parallax_TexCoord.t - 2.0 * sample_far * sample_res));
+
+texel/=10.0;
+
+float threshold_high = max(hud_brightness, 0.05) * 0.7;
+float threshold_low = max(hud_brightness, 0.05) * 0.4;
+float threshold_mid = max(hud_brightness, 0.05) * 0.5;
+
+texel.rgb = mix(texel.rgb, vec3 (1.0, 1.0, 1.0), smoothstep(threshold_mid, threshold_high, texel.a));
+texel.rgb = mix(texel.rgb, vec3 (0.0, 0.0, 0.0), 1.0 - smoothstep(0.0, threshold_low, texel.a));
+
+texel *=gl_Color;
+
+vec2 frost_coords;
+
+if (adaptive_mapping == 1) {frost_coords = gl_TexCoord[0].st * 7.0;}
+else if (adaptive_mapping ==2) {frost_coords = nPos * 7.0;}
+else {frost_coords = vertPos.xy * 7.0;}
+
+frost_texel = texture2D(frost_texture, frost_coords);
+func_texel = texture2D(func_texture, gl_TexCoord[0].st * 2.0);
+
+
+
+float noise_003m = Noise2D(vertPos.xy, 0.03);
+float noise_0003m = Noise2D(vertPos.xy, 0.003);
+
+
+// environment reflection, including a lightmap for the reflections
+
+vec4 reflection = textureCube(cube_texture, refl_vec);
+vec4 reflection_lighting = textureCube(cube_light_texture, refl_vec);
+
+vec3 lightmapcolor = vec3(0.0, 0.0, 0.0);
+
+
+if (use_reflection_lightmap == 1)
+	{
+	vec4 lightmapFactor = vec4(lightmap_r_factor, lightmap_g_factor, lightmap_b_factor, lightmap_a_factor);
+        lightmapFactor = lightmapFactor * reflection_lighting;
+        if (lightmap_multi > 0 )
+		{
+	        lightmapcolor = lightmap_r_color * lightmapFactor.r +
+                lightmap_g_color * lightmapFactor.g +
+                lightmap_b_color * lightmapFactor.b +
+                lightmap_a_color * lightmapFactor.a ;
+            	}
+	 else 
+		{
+                lightmapcolor = reflection_lighting.rgb * lightmap_r_color * lightmapFactor.r;
+            	}
+
+	}
+
+float lightmap_intensity = length(lightmapcolor);
+float light_fraction = clamp(lightmap_intensity / (length(light_diffuse.rgb) + 0.01), 0.0, 5.0);
+
+if (light_fraction < 1.0) {light_fraction = smoothstep(0.7, 1.0, light_fraction);}
+
+
+if (use_reflection ==1)
+	{
+	// to determine whether what we see reflected is currently in light, we make the somewhat drastic
+	// assumption that its normal will be opposite to the glass normal
+	// (which is mostly truish in a normal cockpit)
+	float reflection_shade = ambient_fraction + (1.0-ambient_fraction) * max(0.0, dot (normalize(normal),  normalize(gl_LightSource[0].position.xyz)));
+
+	texel.rgb = mix(texel.rgb, reflection.rgb, (reflection_strength *  reflection_shade  * (1.0-Mie)));
+
+	}
+
+//texel.rgb = mix(texel.rgb, lightmapcolor.rgb, lightmap_intensity);
+
+// overlay pattern
+
+if ((use_mask == 1) && (use_overlay==1))
+	{
+	vec4 overlay_texel = vec4(overlay_color, overlay_alpha);
+	overlay_texel.rgb *=  light_diffuse.rgb* (1.0 + (1.0 + overlay_glare)*Mie);
+	overlay_texel.a *=(1.0 + overlay_glare* Mie);
+	texel = mix(texel, overlay_texel, func_texel.b * overlay_texel.a);
+	}
+
+
+// frost
+
+float fth = (1.0-frost_level) * 0.4 + 0.3;
+float fbl = 0.2 * frost_level;
+ 
+
+float frost_factor =  (fbl + (1.0-fbl)* smoothstep(fth,fth+0.2,noise_003m)) * (4.0 + 4.0* Mie);
+
+
+float background_frost =  0.5 * smoothstep(0.7,1.0,frost_level);
+frost_texel.rgb = mix(frost_texel.rgb, vec3 (0.5,0.5,0.5), (1.0- smoothstep(0.0,0.02,frost_texel.a)));
+frost_texel.a =max(frost_texel.a, background_frost * (1.0- smoothstep(0.0,0.02,frost_texel.a)));
+
+frost_texel *=  vec4(light_diffuse.rgb,0.5) * (1.0 + 3.0 * Mie);
+
+frost_factor = max(frost_factor, 0.8*background_frost);
+
+
+texel.rgb =  mix(texel.rgb, frost_texel.rgb, frost_texel.a * frost_factor * smoothstep(0.0,0.1,frost_level));
+texel.a = max(texel.a, frost_texel.a * frost_level);
+
+// rain splashes
+
+vec3 splash_vec = vec3 (splash_x, splash_y, splash_z);
+float splash_speed = length(splash_vec);
+
+
+float rain_factor = 0.0;
+
+float rnorm = max(rain_norm, ground_splash_norm);
+
+if (rnorm > 0.0)
+	{
+	float droplet_size = (0.5 + 0.8 * rnorm) * (1.0 - 0.1 * splash_speed);
+	vec2 rainPos = vec2 (rawPos.x * splash_speed, rawPos.y / splash_speed );
+	rainPos.y = rainPos.y - 0.1 * smoothstep(1.0,2.0, splash_speed) * osg_SimulationTime;
+	if (splash_angle> 0.0)
+	{	
+	// the dynamically impacting raindrops
+
+	float time_shape = 1.0;
+	float base_rate = 6.0 + 3.0 * rnorm + 4.0 * (splash_speed - 1.0);
+	float base_density = 0.6 * rnorm + 0.4  * (splash_speed -1.0);
+	if ((use_mask ==1)&&(use_wipers==1)) {base_density *= (1.0 - 0.5 * func_texel.g);}
+
+	float time_fact1 = (sin(base_rate*osg_SimulationTime));
+	float time_fact2 = (sin(base_rate*osg_SimulationTime + 1.570));
+	float time_fact3 = (sin(base_rate*osg_SimulationTime + 3.1415));
+	float time_fact4 = (sin(base_rate*osg_SimulationTime + 4.712));
+
+	time_fact1 = smoothstep(0.0,1.0, time_fact1);
+	time_fact2 = smoothstep(0.0,1.0, time_fact2);
+	time_fact3 = smoothstep(0.0,1.0, time_fact3);
+	time_fact4 = smoothstep(0.0,1.0, time_fact4);
+
+    	rain_factor += DotNoise2D(rawPos.xy, 0.02 * droplet_size ,0.5, base_density ) * time_fact1;
+    	rain_factor += DotNoise2D(rainPos.xy, 0.03 * droplet_size,0.4, base_density) * time_fact2;
+    	rain_factor += DotNoise2D(rawPos.xy, 0.04 * droplet_size ,0.3, base_density)* time_fact3;
+    	rain_factor += DotNoise2D(rainPos.xy, 0.05 * droplet_size ,0.25, base_density)* time_fact4;
+	}
+
+
+	// the static pattern of small droplets created by the splashes
+	
+	float sweep = min(1./splash_speed,1.0);
+	if ((use_mask ==1)&&(use_wipers==1)) {sweep *= (1.0 - func_texel.g);}
+	if (adaptive_mapping ==2) {rainPos = nPos;}
+	rain_factor += DropletNoise2D(rainPos.xy, 0.02 * droplet_size ,0.5, 0.6* rnorm * sweep);
+	rain_factor += DotNoise2D(rainPos.xy, 0.012 * droplet_size ,0.7, 0.6* rnorm * sweep);
+	}
+
+rain_factor = smoothstep(0.1,0.2, rain_factor) * (1.0 - smoothstep(0.4,1.0, rain_factor) * (0.2+0.8*noise_0003m));
+
+
+vec4 rainColor = vec4 (0.2,0.2, 0.2, 0.6 - 0.3 * smoothstep(1.0,2.0, splash_speed));
+rainColor.rgb *= length(light_diffuse)/1.73;
+
+
+
+// glass tint
+
+
+vec4 outerColor = mix(texel, rainColor, rain_factor);
+// now mix illuminated reflections in
+
+vec3 reflLitColor = reflection.rgb * lightmapcolor.rgb;
+
+outerColor.rgb = mix(outerColor.rgb, reflLitColor, clamp(reflection_strength * light_fraction,0.0,1.0));
+outerColor.a = max(outerColor.a, 0.1 * light_fraction * reflection_strength);
+
+outerColor  *= tint;
+
+
+
+
+// fogging - this is inside the glass
+
+vec4 fog_texel = vec4 (0.6,0.6,0.6, fog_level);
+
+if (use_mask == 1) {fog_texel.a = fog_texel.a * func_texel.r;}
+
+fog_texel *= vec4(light_diffuse.rgb,1.0); 
+fog_texel.rgb *= (1.0 + 3.0 * Mie);
+fog_texel.a *= min((1.0 + 0.5 * Mie), 0.85);
+
+
+vec4 fragColor;
+
+fragColor.rgb = mix(outerColor.rgb, fog_texel.rgb, fog_texel.a);
+fragColor.a = max(outerColor.a, fog_texel.a);
+
+fragColor.rgb = filter_combined(fragColor.rgb);
+
+
+gl_FragColor = clamp(fragColor,0.0,1.0);
+
+
+}

--- a/Aircraft/JA37/Models/Effects/hud/hud-parallax.vert
+++ b/Aircraft/JA37/Models/Effects/hud/hud-parallax.vert
@@ -1,0 +1,141 @@
+// -*-C++-*-
+#version 120
+
+varying vec2 rawPos;
+varying vec2 nPos;
+varying vec3 vertPos;
+varying vec3 normal;
+varying vec3 light_diffuse;
+varying vec3 refl_vec;
+varying vec3 relPos;
+varying float splash_angle;
+varying float Mie;
+varying float ambient_fraction;
+
+uniform float ground_scattering;
+uniform float hazeLayerAltitude;
+uniform float moonlight;
+uniform float terminator;
+uniform float splash_x;
+uniform float splash_y;
+uniform float splash_z;
+
+const float EarthRadius = 5800000.0;
+const float terminator_width = 200000.0;
+
+float light_func (in float x, in float a, in float b, in float c, in float d, in float e)
+{
+//x = x - 0.5;
+
+// use the asymptotics to shorten computations
+if (x < -15.0) {return 0.0;}
+
+return e / pow((1.0 + a * exp(-b * (x-c)) ),(1.0/d));
+}
+
+
+void main()
+{
+
+vec3 shadedFogColor = vec3(0.55, 0.67, 0.88);
+vec3 moonLightColor = vec3 (0.095, 0.095, 0.15) * moonlight;
+
+// geometry for lighting
+vec4 ep = gl_ModelViewMatrixInverse * vec4(0.0,0.0,0.0,1.0);
+relPos = gl_Vertex.xyz - ep.xyz;
+vec3 lightFull = (gl_ModelViewMatrixInverse * gl_LightSource[0].position).xyz;
+vec3 lightHorizon = normalize(vec3(lightFull.x,lightFull.y, 0.0));
+float dist = length(relPos);
+float vertex_alt = max(gl_Vertex.z,100.0);
+float scattering = ground_scattering + (1.0 - ground_scattering) * smoothstep(hazeLayerAltitude -100.0, hazeLayerAltitude + 100.0, vertex_alt); 
+float yprime_alt = - sqrt(2.0 * EarthRadius * vertex_alt);
+float earthShade = 0.6 * (1.0 - smoothstep(-terminator_width+ terminator, terminator_width + terminator, yprime_alt)) + 0.4;
+float lightArg = (terminator-yprime_alt)/100000.0;
+
+// light computation
+
+vec3 light_ambient;
+
+light_diffuse.b = light_func(lightArg, 1.330e-05, 0.264, 3.827, 1.08e-05, 1.0);
+light_diffuse.g = light_func(lightArg, 3.931e-06, 0.264, 3.827, 7.93e-06, 1.0);
+light_diffuse.r = light_func(lightArg, 8.305e-06, 0.161, 3.827, 3.04e-05, 1.0);
+light_diffuse = light_diffuse * scattering;
+
+
+light_ambient.r = light_func(lightArg, 0.236, 0.253, 1.073, 0.572, 0.33);
+light_ambient.g = light_ambient.r * 0.4/0.33; 
+light_ambient.b = light_ambient.r * 0.5/0.33; 
+
+float intensity;
+
+if (earthShade < 0.5)
+	{
+	intensity = length(light_ambient.xyz); 
+
+	light_ambient.rgb = intensity * normalize(mix(light_ambient.rgb,  shadedFogColor, 1.0 -smoothstep(0.4, 0.8,earthShade) ));
+	light_ambient.rgb = light_ambient.rgb +   moonLightColor *  (1.0 - smoothstep(0.4, 0.5, earthShade));
+
+	intensity = length(light_diffuse.xyz); 
+	light_diffuse.rgb = intensity * normalize(mix(light_diffuse.rgb,  shadedFogColor, 1.0 -smoothstep(0.4, 0.7,earthShade) ));
+	}
+
+
+float MieFactor =   dot(normalize(lightFull), normalize(relPos));
+Mie =  smoothstep(0.9,1.0, MieFactor) * earthShade * earthShade * scattering;
+
+
+// get a reflection vector for cube map
+
+vec4 ecPosition = gl_ModelViewMatrix * gl_Vertex;
+normal = -normalize(gl_NormalMatrix * gl_Normal);
+vec4 reflect_eye = vec4(reflect(ecPosition.xyz, normal), 0.0);
+vec3 reflVec_stat = normalize(gl_ModelViewMatrixInverse * reflect_eye).xyz;
+refl_vec = reflVec_stat;
+
+// get a projection plane orthogonal to the splash vector
+
+vec3 splash_vec = vec3 (splash_x, splash_y, splash_z);
+vec3 corrected_splash = normalize(splash_vec);
+
+float angle = abs(dot(corrected_splash, gl_Normal));
+
+
+//corrected_splash = normalize(corrected_splash + 0.4* gl_Normal );
+	
+
+vec3 base_1 = vec3 (-corrected_splash.y, corrected_splash.x, 0.0);
+vec3 base_2 = cross (corrected_splash, base_1);
+
+base_1 = normalize(base_1);
+base_2 = normalize(base_2);
+
+rawPos = vec2 (dot(gl_Vertex.xyz, base_1), dot(gl_Vertex.xyz, base_2));
+
+base_1 = vec3 (-gl_Normal.y, gl_Normal.x, 0.0);
+base_2 = cross(gl_Normal, base_1);
+
+base_1 = normalize(base_1);
+base_2 = normalize(base_2);
+
+nPos = vec2 (dot(gl_Vertex.xyz, base_1), dot(gl_Vertex.xyz, base_2));
+
+vertPos = gl_Vertex.xyz;
+
+splash_angle = dot(gl_Normal, corrected_splash);
+
+ambient_fraction = length(light_ambient.rgb)/(length(light_diffuse.rgb +light_ambient.rgb ) + 0.01);
+
+
+gl_Position = ftransform();
+gl_TexCoord[0] = gl_TextureMatrix[0] * gl_MultiTexCoord0;
+
+vec4 diffuse_color = gl_FrontMaterial.diffuse;
+vec4 ambient_color = gl_FrontMaterial.ambient;
+
+vec4 constant_term = gl_FrontMaterial.emission + ambient_color * vec4 (light_diffuse.rgb + light_ambient.rgb,1.0);
+constant_term.a = min(diffuse_color.a, ambient_color.a);
+
+gl_FrontColor = constant_term;
+gl_BackColor = gl_FrontColor;
+
+}

--- a/Aircraft/JA37/Models/Effects/hud/hud-parallax.vert
+++ b/Aircraft/JA37/Models/Effects/hud/hud-parallax.vert
@@ -19,6 +19,8 @@ uniform float terminator;
 uniform float splash_x;
 uniform float splash_y;
 uniform float splash_z;
+
+uniform bool use_parallax;
 uniform float optical_yaw;
 uniform float optical_pitch;
 uniform float optical_roll;
@@ -145,18 +147,20 @@ splash_angle = dot(gl_Normal, corrected_splash);
 
 ambient_fraction = length(light_ambient.rgb)/(length(light_diffuse.rgb +light_ambient.rgb ) + 0.01);
 
-// Eye to vertex vector in the optical centerline coordinate system
-mat4 RotMatPR;
-mat4 RotMatH;
-float cosRx = cos(radians(-optical_roll));
-float sinRx = sin(radians(-optical_roll));
-float cosRy = cos(radians(optical_pitch));
-float sinRy = sin(radians(optical_pitch));
-float cosRz = cos(radians(-optical_yaw));
-float sinRz = sin(radians(-optical_yaw));
-rotationMatrixPR(sinRx, cosRx, sinRy, cosRy, RotMatPR);
-rotationMatrixH(sinRz, cosRz, RotMatH);
-optical_relpos = (RotMatH * (RotMatPR * (gl_Vertex - ep))).xyz;
+// Eye to vertex vector in the optical centerline coordinate system, for parallax correction.
+if (use_parallax) {
+	mat4 RotMatPR;
+	mat4 RotMatH;
+	float cosRx = cos(radians(-optical_roll));
+	float sinRx = sin(radians(-optical_roll));
+	float cosRy = cos(radians(optical_pitch));
+	float sinRy = sin(radians(optical_pitch));
+	float cosRz = cos(radians(-optical_yaw));
+	float sinRz = sin(radians(-optical_yaw));
+	rotationMatrixPR(sinRx, cosRx, sinRy, cosRy, RotMatPR);
+	rotationMatrixH(sinRz, cosRz, RotMatH);
+	optical_relpos = (RotMatH * (RotMatPR * (gl_Vertex - ep))).xyz;
+}
 
 
 gl_Position = ftransform();

--- a/Aircraft/JA37/Nasal/ja37.nas
+++ b/Aircraft/JA37/Nasal/ja37.nas
@@ -531,7 +531,7 @@ var Saab37 = {
     me.theShakeEffect();
     # The HUD should not shake (relative to the background).
     # This requires to update the hud translation just after head movements.
-    canvas_HUD.hud_pilot.followHeadPosition();
+    #canvas_HUD.hud_pilot.followHeadPosition();
 
     logTime();
   

--- a/Aircraft/JA37/Nasal/ja37.nas
+++ b/Aircraft/JA37/Nasal/ja37.nas
@@ -529,9 +529,6 @@ var Saab37 = {
     input.rainVol.setDoubleValue(me.rain*0.35*me.vol);
 
     me.theShakeEffect();
-    # The HUD should not shake (relative to the background).
-    # This requires to update the hud translation just after head movements.
-    #canvas_HUD.hud_pilot.followHeadPosition();
 
     logTime();
   

--- a/Aircraft/JA37/Nasal/radar/radar-logic.nas
+++ b/Aircraft/JA37/Nasal/radar/radar-logic.nas
@@ -1256,8 +1256,8 @@ var Contact = {
       me.dir_y  = math.atan2(round0(me.vel_bz), math.max(me.vel_bx, 0.001)) * R2D;
       me.dir_x  = math.atan2(round0(me.vel_by), math.max(me.vel_bx, 0.001)) * R2D;
 
-      var hud_pos_x = canvas_HUD.pixelPerDegreeX * me.dir_x;
-      var hud_pos_y = canvas_HUD.centerOffset + canvas_HUD.pixelPerDegreeY * me.dir_y;
+      var hud_pos_x = canvas_HUD.pixelPerDegree * me.dir_x;
+      var hud_pos_y = canvas_HUD.centerOffset + canvas_HUD.pixelPerDegree * me.dir_y;
 
       return [hud_pos_x, hud_pos_y];
     },
@@ -1545,8 +1545,8 @@ var ContactGPS = {
     me.dir_y  = math.atan2(round0(me.vel_bz), math.max(me.vel_bx, 0.001)) * R2D;
     me.dir_x  = math.atan2(round0(me.vel_by), math.max(me.vel_bx, 0.001)) * R2D;
 
-    var hud_pos_x = canvas_HUD.pixelPerDegreeX * me.dir_x;
-    var hud_pos_y = canvas_HUD.centerOffset + canvas_HUD.pixelPerDegreeY * me.dir_y;
+    var hud_pos_x = canvas_HUD.pixelPerDegree * me.dir_x;
+    var hud_pos_y = canvas_HUD.centerOffset + canvas_HUD.pixelPerDegree * me.dir_y;
 
     return [hud_pos_x, hud_pos_y];
   },
@@ -1866,8 +1866,8 @@ var ContactGhost = {
       ya_rad = ya_rad + 2*math.pi;
     }
 
-    var hud_pos_x = canvas_HUD.pixelPerDegreeX * xa_rad * rad2deg;
-    var hud_pos_y = canvas_HUD.centerOffset + canvas_HUD.pixelPerDegreeY * -ya_rad * rad2deg;
+    var hud_pos_x = canvas_HUD.pixelPerDegree * xa_rad * rad2deg;
+    var hud_pos_y = canvas_HUD.centerOffset + canvas_HUD.pixelPerDegree * -ya_rad * rad2deg;
 
     return [hud_pos_x, hud_pos_y];
   },


### PR DESCRIPTION
Uses the shader to do a parallax effect, instead of applying a transformation in canvas.
Advantages:
- Removes the stuttering (nasal will always be at least 1 frame late)
- Removes the scaling of the canvas, which messed up some minor things my changing the effective resolution. For instance the image was blurry when moving the head very close to the hud, and I think the brightness/line width did not quite work as expected.
- The canvas texture is in tangent space: a point at angles `(a,b)` from the aircraft centerline (relative to the view position) is mapped to `(tan(a), tan(b))` in the texture space.
This continues to work no matter the shape of the object used as hud. In particular, a slanted surface can be used without deformation.

To do:
- [x] Add a parameter to specify the angle occupied by the texture
- [x] Currently the hud optical center line (i.e. the direction mapped to the texture center) is the `-x` axis in the model space. Unless the hud object is rotated, this corresponds to the aircraft forward axis.
I think it actually makes sense to use the model space here: rotations applied to the hud object will be taken into account. However I need to add parameters to tweak the axis (essentially an additional rotation matrix).
- [ ] I think this should simplify the angle computations in `hud.nas`, but of course they are messed up right now.
- [x] Related to the previous point: the texture is in the 'tangent space' (angle `(a,b)` -> coord `(tan(a), tan(b))` on the texture). This is in part because it's the simplest to implement, and in part because it was what we had before. 
I'm not sure if this is really the correct choice. It would be easy to change it, for instance to use 'angle space' (angle `(a,b)` -> coord `(a,b)` on the texture). My main issue with the latter is that it is not euclidean, but I think it is still worth checking, it might actually result in less deformations.
- [x] Make parallax correction opt-in, so that the effect is backward compatible.

Regarding the implementation, there really is only one relevant line:
```
vec2 parallax_TexCoord = -relPos.yz / relPos.x * 3 + vec2(0.5, 0.5);
```
`relPos` is the eye to fragment vector in the model space. This turns it into a texture coordinate.
`3` scales the image, it should depend on the texture angular size (cf. point 1 in to do list).
`vec2(0.5, 0.5)` is to center the texture.

Once ready, I think this could be merged into FGData. I guess it would require to make it backward compatible, with an option to disable it.