### PR TITLE
Fixes to `missile.nas` for cruise missiles

### DIFF
--- a/Aircraft/JA37/Nasal/payload/missiles.nas
+++ b/Aircraft/JA37/Nasal/payload/missiles.nas
@@ -5029,9 +5029,6 @@ var AIM = {
 	},
 	
 	steering_speed_G: func(meHeading, mePitch, steering_e_deg, steering_h_deg, s_fps, dt) {
-		if (s_fps == 0) {
-			return 0;
-		}
 		# Get G number from steering (e, h) in deg, speed in ft/s.
 		me.meVector = me.myMath.eulerToCartesian3X(-meHeading, mePitch, 0);
 		me.meVectorN= me.myMath.normalize(me.meVector);

--- a/Aircraft/JA37/Nasal/payload/missiles.nas
+++ b/Aircraft/JA37/Nasal/payload/missiles.nas
@@ -2182,7 +2182,7 @@ var AIM = {
 			# missile still on rail, lets calculate its speed relative to the wind coming in from the aircraft nose.
 			me.rail_speed_into_wind = me.rail_speed_into_wind + me.speed_change_fps;
 			#printf("Rail: ms_fps=%d", me.rail_speed_into_wind);
-		} elsif (me.observing != "gyro-pitch" or (me.speed_m < me.min_speed_for_guiding and me.tooLowSpeedPass)) {
+		} else {
 			# gravity acc makes the weapon pitch down			
 			me.pitch = math.atan2(-me.speed_down_fps, me.speed_horizontal_fps ) * R2D;
 		}

--- a/Aircraft/JA37/Nasal/payload/missiles.nas
+++ b/Aircraft/JA37/Nasal/payload/missiles.nas
@@ -5025,7 +5025,7 @@ var AIM = {
 	
 	steering_speed_G: func(meHeading, mePitch, steering_e_deg, steering_h_deg, s_fps, dt) {
 		if (s_fps == 0) {
-			return 1;
+			return 0;
 		}
 		# Get G number from steering (e, h) in deg, speed in ft/s.
 		me.meVector = me.myMath.eulerToCartesian3X(-meHeading, mePitch, 0);
@@ -5034,11 +5034,9 @@ var AIM = {
 		me.itVector = me.myMath.eulerToCartesian3X(-(meHeading+steering_h_deg), mePitch+steering_e_deg, 0);
 		me.itVector = me.myMath.normalize(me.itVector);
 		me.itVector = me.myMath.product(s_fps, me.itVector);#velocity vector if doing that steering
-		me.grVector  = [0,0,dt*g_fps];#velocity vector due to fighting gravity
 			
 		# Delta lateral velocity
 		me.dv = me.myMath.minus(me.itVector, me.meVector);
-		me.dv = me.myMath.plus(me.dv, me.grVector);
 		me.dv = me.myMath.projVectorOnPlane(me.meVectorN, me.dv);		
 		me.dv = me.myMath.magnitudeVector(me.dv);
 		

--- a/Aircraft/JA37/Nasal/payload/missiles.nas
+++ b/Aircraft/JA37/Nasal/payload/missiles.nas
@@ -671,6 +671,7 @@ var AIM = {
 		m.speed_down_fps  = nil;
 		m.speed_east_fps  = nil;
 		m.speed_north_fps = nil;
+		m.speed_horizontal_fps = nil;
 		m.alt_ft          = nil;
 		m.pitch           = nil;
 		m.hdg             = nil;
@@ -1414,6 +1415,7 @@ var AIM = {
 		me.speed_down_fps = getprop("velocities/speed-down-fps");
 		me.speed_east_fps = getprop("velocities/speed-east-fps");
 		me.speed_north_fps = getprop("velocities/speed-north-fps");
+		me.speed_horizontal_fps = math.sqrt(me.speed_east_fps*me.speed_east_fps + me.speed_north_fps*me.speed_north_fps);
 		if (me.rail == TRUE) {
 			if (me.rail_forward == FALSE) {
 					me.u = noseAir.getValue();
@@ -1426,15 +1428,14 @@ var AIM = {
 			}
 		} elsif (me.intoBore == FALSE and me.eject_speed == 0) {
 			# to prevent the missile from falling up, we need to sometimes pitch it into wind:
-			var h_spd = math.sqrt(me.speed_east_fps*me.speed_east_fps + me.speed_north_fps*me.speed_north_fps);
 			#var t_spd = math.sqrt(me.speed_down_fps*me.speed_down_fps + h_spd*h_spd);
-			var wind_pitch = math.atan2(-me.speed_down_fps, h_spd) * R2D;
+			var wind_pitch = math.atan2(-me.speed_down_fps, me.speed_horizontal_fps) * R2D;
 			if (wind_pitch < ac_pitch) {
 				# super hack, and might temporary as missile leaves launch platform look stupid:
 				ac_pitch = wind_pitch;
 				# this should really take place over a duration instead of instantanious.
 			}
-			if (h_spd != 0) {
+			if (me.speed_horizontal_fps != 0) {
 				# will turn weapon into wind
 				# (not sure this is a good idea..might lose lock immediatly if firing with a big AoA,
 				# but then on other hand why would you do that, unless in dogfight, and there you use aim9 anyway,

--- a/Aircraft/JA37/Nasal/payload/missiles.nas
+++ b/Aircraft/JA37/Nasal/payload/missiles.nas
@@ -3245,7 +3245,9 @@ var AIM = {
 	                    #Checking if the distance to the intersection is before or after geoPlus4
 	                    }else{
 	                        GroundIntersectCoord.set_latlon(GroundIntersectResult.lat, GroundIntersectResult.lon, GroundIntersectResult.elevation);
-	                        if(me.coord.direct_distance_to(GroundIntersectCoord)>distance_Target){
+	                        # Factor 0.95 to account for error in the two distance computations.
+	                        # Otherwise falso positive obstacle detection occurs.
+	                        if(me.coord.direct_distance_to(GroundIntersectCoord) > 0.95 * distance_Target){
 	                            No_terrain = 1;
 	                        }else{
 	                            #Raising geoPlus4 altitude by 100 meters


### PR DESCRIPTION
Bunch of fixes in the missile code, for the Rb 04 and Rb 15:
* First two commits are standby (no lock) guidance modes for cruise missiles (fix `level`, add `terrain-follow`).
* 3rd commit fixes that `steering_speed_G` always overestimated G-load by 1 (in level flight) by effectively counting for gravity twice.
For instance free-falling stuff would report a G-load of 1, and missiles in level flight would report a G-load of 2.
It should improve the performance of everything a bit, but it should be mostly noticeable on gliding bombs and low-power cruise missiles.
* 4th commit fixes an hysteresis problem in the terrain following code, which caused anything using terrain following (but not the ones using pure sea-skimming) to under-perform massively. Over sea/flat terrain the problem is gone entirely. Over hills, there is still a significant improvement.
* 5th commit makes sure that the `min_speed_for_guidance` test is always done---it was skipped for many 'non-standard' guidance modes.

Commit 4 will require to check the parameters of anything using terrain follow in the fleet.
I believe they all are 1. severely underperforming or 2. modified with magic 3x engine power to work around the issue.