### PR TITLE
missile.nas: Fix caged and locked seeker behaviour

### DIFF
--- a/Aircraft/JA37/Nasal/payload/missiles.nas
+++ b/Aircraft/JA37/Nasal/payload/missiles.nas
@@ -4680,12 +4680,21 @@ var AIM = {
 
 			me.curr_deviation_e = deviation_normdeg(OurPitch.getValue(), me.Tgt.getElevation());
 			me.curr_deviation_h = deviation_normdeg(OurHdg.getValue(), me.Tgt.get_bearing());
-			if (!me.caged) {
+			if (!me.caged or (me.mode_slave and me.command_tgt)) {
 				me.seeker_elev_target = me.curr_deviation_e;
 				me.seeker_head_target = me.curr_deviation_h;
 				me.rotateTarget();
 				me.moveSeeker();
-			}			
+			} elsif (me.mode_bore) {
+				me.seeker_elev_target = 0;
+				me.seeker_head_target = 0;
+				me.moveSeeker();
+			} elsif (me.mode_slave and !me.command_tgt) {
+				me.seeker_elev_target = me.command_dir_pitch;
+				me.seeker_head_target = me.command_dir_heading;
+				me.moveSeeker();
+			}
+
 			me.seeker_elev_target = me.curr_deviation_e;
 			me.seeker_head_target = me.curr_deviation_h;
 			me.rotateTarget();


### PR DESCRIPTION
This fixes `commandDir` when the seeker is caged and locked (currently, it does nothing until the seeker loses lock).

In bore sight mode or slaved+`commandDir` mode, if the seeker is uncaged and locked,
then re-caging it now resets the seeker to the bore-sight/commanded position (previously, it did not reset until lock was lost).

It also allows to have a manually controlled seeker through `commandDir`, which I want to use for the Rb 75
(previously, this would result in the seeker refusing to move when it has lock).

See commit message for details.