### PR TITLE
Autothrottle AoA G-load correction

### DIFF
--- a/Aircraft/JA37/Systems/autoflight-rules.xml
+++ b/Aircraft/JA37/Systems/autoflight-rules.xml
@@ -219,14 +219,6 @@
 		</config>
 	</pid-controller>
 	
-	<predict-simple>
-		<name>Alpha Predict</name>
-		<input>/fdm/jsbsim/aero/alpha-deg</input> <!-- Really should be indicated -->
-		<output>/fdm/jsbsim/aero/alpha-deg-ahead</output>
-		<seconds>1.0</seconds>
-		<filter-gain>0.0</filter-gain>
-	</predict-simple>
-	
 	<pid-controller>
 		<name>Alpha Hold</name>
 		<enable>
@@ -243,7 +235,18 @@
 				</and>
 			</condition>
 		</enable>
-		<input>/fdm/jsbsim/aero/alpha-deg-ahead</input>
+		<input>
+			<expression>
+			<!-- Autothrottle compensates alpha information for g-load, so as to maintain 
+				the airspeed corresponding to the target alpha at g-load=1 (JA SFI chap 1 sec 11.5.1-2).
+				As first approximation, g-load and alpha are proportional at fixed airspeed,
+				so maintaining their ratio is roughly the same as maintaining airspeed. -->
+				<div>
+					<property>/fdm/jsbsim/aero/alpha-deg</property> <!-- Really should be indicated -->
+					<property>/fdm/jsbsim/instruments/g-force</property>
+				</div>
+			</expression>
+		</input>
 		<reference>/fdm/jsbsim/systems/flight/approach-alpha</reference>
 		<output>/controls/engines/engine[0]/throttle-pid</output>
 		<config>


### PR DESCRIPTION
From JA manual chap 1 sec 11 par 5.1: autothrottle in alpha mode corrects alpha for g-load, so that it maintains an airspeed corresponding to the target alpha at 1g.
This implements this correction by simply dividing alpha by g-load at the PID input (at fixed airspeed, alpha and g-load are very close to proportional). I also removed the alpha prediction filter at the PID input, I think it works well without it now that we're not trying to fight alpha increase at higher loads.

This makes the autothrottle much more stable on approach (previously, any pitch up moment caused a quick throttle up, further increasing pitch up moment—which seems almost unavoidable when actually trying to maintain alpha).

@Octal450 What do you think of that?